### PR TITLE
add static-build target in Makefile with built-in nlopt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,5 @@ bin/
 
 # Code editor settings
 .vscode
+
+viam-ufactory-xarm

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,9 @@ build:
 	rm -rf bin
 	go build -o $(BIN_OUTPUT_PATH)/viam-xarm
 
+static-build:
+	go build -ldflags "-extld=$(PWD)/etc/ld_wrapper.sh -s -extldflags=-lm" .
+
 module: build
 	rm -f $(BIN_OUTPUT_PATH)/module.tar.gz
 	tar czf $(BIN_OUTPUT_PATH)/module.tar.gz $(BIN_OUTPUT_PATH)/viam-xarm meta.json

--- a/etc/ld_wrapper.sh
+++ b/etc/ld_wrapper.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+set -eu
+
+# find the real linker, from env or same defaults as go
+REAL_LD="${CC}"
+if [[ -z "${REAL_LD}" ]]; then
+	REAL_LD="$(which gcc)"
+fi
+if [[ -z "${REAL_LD}" ]]; then
+	REAL_LD="$(which clang)"
+fi
+
+
+ARGS=("$@")
+
+# list of linker arguments to ignore
+STRIPPED_ARGS="-g -O2"
+
+# list of arguments to prefix with -Bstatic
+STATIC_ARGS="-lx264 -lnlopt -lstdc++"
+
+# add explicit static standard library flags
+FILTERED=("-static-libgcc" "-static-libstdc++")
+# Loop through the arguments and filter
+for ARG in "${ARGS[@]}"; do
+	if [[ "${STRIPPED_ARGS[@]}" =~ "${ARG}" ]]; then
+		# don't forward the arg
+		:
+	elif [[ "${STATIC_ARGS[@]}" =~ "${ARG}" ]]; then
+		# wrap the arg as a static one
+		FILTERED+=("-Wl,-Bstatic" "${ARG}" "-Wl,-Bdynamic")
+	else
+		# pass through with no filtering
+		FILTERED+=("${ARG}")
+	fi
+done
+
+# add libstdc++ statically (and last)
+FILTERED+=("-Wl,-Bstatic" "-lstdc++" "-Wl,-Bdynamic")
+
+# call the real linker with the filtered arguments
+
+set -x
+
+exec "$REAL_LD" "${FILTERED[@]}"


### PR DESCRIPTION
## What changed
- add `make static-build` target and `ld_wrapper.sh` adapted from RDK's [here](https://github.com/viamrobotics/rdk/blob/main/etc/ld_wrapper.sh)
## Why
RDK includes a static copy of nlopt so that binaries don't have ABI issues with nlopt on the target system. This PR copies that approach so this module can run anywhere (for some definition of anywhere).
## Manual test
Build
```sh
$ docker run -it --rm -v $PWD:/host ghcr.io/viamrobotics/cloud-build-base:amd64
root@58495a51598c:/# cd /host
root@58495a51598c:/host# make static-build
go build -ldflags "-extld=/host/etc/ld_wrapper.sh -s -extldflags=-lm" .
go: downloading go1.24.1 (linux/amd64)
...
go: downloading github.com/felixge/httpsnoop v1.0.4
# github.com/viam-modules/viam-ufactory-xarm
+ exec gcc -static-libgcc -static-libstdc++ -m64 -s -Wl,--build-id=0x1e249769127f2c4dca534374d547b837505e6d62 -o $WORK/b001/exe/a.out -Wl,--export-dynamic-symbol=_cgo_panic -Wl,--export-dynamic-symbol=_cgo_topofstack -Wl,--export-dynamic-symbol=crosscall2 -Wl,--export-dynamic-symbol=nloptFunc -Wl,--export-dynamic-symbol=nloptMfunc -Wl,--compress-debug-sections=zlib /tmp/go-link-493238810/go.o /tmp/go-link-493238810/000000.o /tmp/go-link-493238810/000001.o /tmp/go-link-493238810/000002.o /tmp/go-link-493238810/000003.o /tmp/go-link-493238810/000004.o /tmp/go-link-493238810/000005.o /tmp/go-link-493238810/000006.o /tmp/go-link-493238810/000007.o /tmp/go-link-493238810/000008.o /tmp/go-link-493238810/000009.o /tmp/go-link-493238810/000010.o /tmp/go-link-493238810/000011.o /tmp/go-link-493238810/000012.o /tmp/go-link-493238810/000013.o /tmp/go-link-493238810/000014.o /tmp/go-link-493238810/000015.o /tmp/go-link-493238810/000016.o /tmp/go-link-493238810/000017.o /tmp/go-link-493238810/000018.o /tmp/go-link-493238810/000019.o /tmp/go-link-493238810/000020.o /tmp/go-link-493238810/000021.o /tmp/go-link-493238810/000022.o /tmp/go-link-493238810/000023.o /tmp/go-link-493238810/000024.o /tmp/go-link-493238810/000025.o -lresolv -lpthread -lm -Wl,-Bstatic -lnlopt -Wl,-Bdynamic -no-pie -lm -Wl,-Bstatic -lstdc++ -Wl,-Bdynamic
```
ldd and run inside container
```sh
root@58495a51598c:/host# ldd viam-ufactory-xarm 
	linux-vdso.so.1 (0x00007ffc7e5fb000)
	libresolv.so.2 => /lib/x86_64-linux-gnu/libresolv.so.2 (0x00007101b2369000)
	libpthread.so.0 => /lib/x86_64-linux-gnu/libpthread.so.0 (0x00007101b2347000)
	libm.so.6 => /lib/x86_64-linux-gnu/libm.so.6 (0x00007101b2203000)
	libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007101b202f000)
	/lib64/ld-linux-x86-64.so.2 (0x00007101b238e000)
root@58495a51598c:/host# ./viam-ufactory-xarm 
2025-05-02T19:52:14.429Z	ERROR		utils@v0.1.130/runtime.go:70	need socket path as command line argument
```
ldd + run outside container
```sh
root@58495a51598c:/host# exit
exit
$ ldd viam-ufactory-xarm 
	linux-vdso.so.1 (0x00007fff205e3000)
	libresolv.so.2 => /lib/x86_64-linux-gnu/libresolv.so.2 (0x000076e3b3624000)
	libpthread.so.0 => /lib/x86_64-linux-gnu/libpthread.so.0 (0x000076e3b361f000)
	libm.so.6 => /lib/x86_64-linux-gnu/libm.so.6 (0x000076e3b3538000)
	libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x000076e3b3200000)
	/lib64/ld-linux-x86-64.so.2 (0x000076e3b3664000)
$ ./viam-ufactory-xarm 
2025-05-02T19:52:20.697Z	ERROR		utils@v0.1.130/runtime.go:70	need socket path as command line argument
```