### PR TITLE
RSDK-10850 Fix loads do command

### DIFF
--- a/arm/comm.go
+++ b/arm/comm.go
@@ -768,15 +768,18 @@ func (x *xArm) openVacuum(ctx context.Context) error {
 	return nil
 }
 
-func (x *xArm) getLoad(ctx context.Context) (map[string]interface{}, error) {
+func (x *xArm) getLoad(ctx context.Context) ([]float64, error) {
 	c := x.newCmd(regMap["CurrentTorque"])
 	// ~ c.params = append(c.params, 0x01)
 	loadData, err := x.send(ctx, c, true)
+	if err != nil {
+		return []float64{}, err
+	}
 	var loads []float64
 	for i := 0; i < x.dof; i++ {
 		idx := i*4 + 1
 		loads = append(loads, float64(rutils.Float32FromBytesLE((loadData.params[idx : idx+4]))))
 	}
 
-	return map[string]interface{}{"load": loads}, err
+	return loads, nil
 }

--- a/arm/gripper.go
+++ b/arm/gripper.go
@@ -135,13 +135,13 @@ func (g *myGripper) goToPosition(ctx context.Context, goal int) (int, error) {
 
 func (g *myGripper) getPosition(ctx context.Context) (int, error) {
 	res, err := g.arm.DoCommand(ctx, map[string]interface{}{
-		"get_gripper": true,
+		getGripperKey: true,
 	})
 	if err != nil {
 		return 0, err
 	}
 
-	raw := res["gripper_position"]
+	raw := res[gripperPositionKey]
 	pos, ok := raw.(float64)
 	if !ok {
 		return 0, fmt.Errorf("bad gripper_position (%v) %T", raw, raw)

--- a/arm/vacuum_gripper.go
+++ b/arm/vacuum_gripper.go
@@ -65,7 +65,7 @@ func (g *myVacuumGripper) Grab(ctx context.Context, extra map[string]interface{}
 
 	{
 		_, err := g.arm.DoCommand(ctx, map[string]interface{}{
-			"grab_vacuum": true,
+			grabVacuumKey: true,
 		})
 		if err != nil {
 			return false, err
@@ -81,7 +81,7 @@ func (g *myVacuumGripper) Open(ctx context.Context, extra map[string]interface{}
 
 	{
 		_, err := g.arm.DoCommand(ctx, map[string]interface{}{
-			"open_vacuum": true,
+			openVacuumKey: true,
 		})
 		if err != nil {
 			return err

--- a/arm/xarm.go
+++ b/arm/xarm.go
@@ -28,6 +28,9 @@ const (
 	defaultMoveHz = 100. // Don't change this
 
 	interwaypointAccel = 600. // degrees per second per second. All xarms max out at 1145
+
+	// DoCommand keys
+	loadKey = "load"
 )
 
 //go:embed xarm6_kinematics.json
@@ -343,7 +346,7 @@ func (x *xArm) DoCommand(ctx context.Context, cmd map[string]interface{}) (map[s
 		validCommand = true
 	}
 
-	if _, ok := cmd["load"]; ok {
+	if _, ok := cmd[loadKey]; ok {
 		if err := x.setupGripper(ctx); err != nil {
 			return nil, err
 		}
@@ -351,11 +354,7 @@ func (x *xArm) DoCommand(ctx context.Context, cmd map[string]interface{}) (map[s
 		if err != nil {
 			return nil, err
 		}
-		loadInformationInterface, ok := loadInformation["loads"]
-		if !ok {
-			return nil, errors.New("could not read loadInformation")
-		}
-		resp["load"] = loadInformationInterface
+		resp["load"] = loadInformation
 		validCommand = true
 	}
 	if val, ok := cmd["set_speed"]; ok {

--- a/arm/xarm.go
+++ b/arm/xarm.go
@@ -30,7 +30,14 @@ const (
 	interwaypointAccel = 600. // degrees per second per second. All xarms max out at 1145
 
 	// DoCommand keys
-	loadKey = "load"
+	loadKey            = "load"
+	moveGripperKey     = "move_gripper"
+	getGripperKey      = "get_gripper"
+	gripperPositionKey = "gripper_position"
+	setAcckey          = "set_acceleration"
+	setSpeedKey        = "set_speed"
+	grabVacuumKey      = "grab_vacuum"
+	openVacuumKey      = "open_vacuum"
 )
 
 //go:embed xarm6_kinematics.json
@@ -324,7 +331,7 @@ func (x *xArm) DoCommand(ctx context.Context, cmd map[string]interface{}) (map[s
 	resp := map[string]interface{}{}
 	validCommand := false
 
-	if val, ok := cmd["move_gripper"]; ok {
+	if val, ok := cmd[moveGripperKey]; ok {
 		if err := x.setupGripper(ctx); err != nil {
 			return nil, err
 		}
@@ -337,12 +344,12 @@ func (x *xArm) DoCommand(ctx context.Context, cmd map[string]interface{}) (map[s
 		}
 		validCommand = true
 	}
-	if _, ok := cmd["get_gripper"]; ok {
+	if _, ok := cmd[getGripperKey]; ok {
 		pos, err := x.getGripperPosition(ctx)
 		if err != nil {
 			return nil, err
 		}
-		resp["gripper_position"] = float64(pos)
+		resp[gripperPositionKey] = float64(pos)
 		validCommand = true
 	}
 
@@ -357,7 +364,7 @@ func (x *xArm) DoCommand(ctx context.Context, cmd map[string]interface{}) (map[s
 		resp[loadKey] = loadInformation
 		validCommand = true
 	}
-	if val, ok := cmd["set_speed"]; ok {
+	if val, ok := cmd[setSpeedKey]; ok {
 		speed, err := utils.AssertType[float64](val)
 		if err != nil {
 			return nil, err
@@ -370,7 +377,7 @@ func (x *xArm) DoCommand(ctx context.Context, cmd map[string]interface{}) (map[s
 		x.confLock.Unlock()
 		validCommand = true
 	}
-	if val, ok := cmd["set_acceleration"]; ok {
+	if val, ok := cmd[setAcckey]; ok {
 		acceleration, err := utils.AssertType[float64](val)
 		if err != nil {
 			return nil, err
@@ -383,8 +390,8 @@ func (x *xArm) DoCommand(ctx context.Context, cmd map[string]interface{}) (map[s
 		x.confLock.Unlock()
 		validCommand = true
 	}
-	if _, ok := cmd["grab_vacuum"]; ok {
-		_, ok := cmd["grab_vacuum"].(bool)
+	if _, ok := cmd[grabVacuumKey]; ok {
+		_, ok := cmd[grabVacuumKey].(bool)
 		if !ok {
 			return nil, errors.New("could not read grab_vacuum")
 		}
@@ -393,8 +400,8 @@ func (x *xArm) DoCommand(ctx context.Context, cmd map[string]interface{}) (map[s
 		}
 		validCommand = true
 	}
-	if _, ok := cmd["open_vacuum"]; ok {
-		_, ok := cmd["open_vacuum"].(bool)
+	if _, ok := cmd[openVacuumKey]; ok {
+		_, ok := cmd[openVacuumKey].(bool)
 		if !ok {
 			return nil, errors.New("could not read close_vacuum")
 		}

--- a/arm/xarm.go
+++ b/arm/xarm.go
@@ -354,7 +354,7 @@ func (x *xArm) DoCommand(ctx context.Context, cmd map[string]interface{}) (map[s
 		if err != nil {
 			return nil, err
 		}
-		resp["load"] = loadInformation
+		resp[loadKey] = loadInformation
 		validCommand = true
 	}
 	if val, ok := cmd["set_speed"]; ok {


### PR DESCRIPTION
Eliot pointed out that the loads docommand returned an error, this was due to an incorrect key being used. Created a constant for the key and cleaned up the getLoad function. 