### PR TITLE
[RSDK-11247] Add gripper_lite model to support two fingers gripper found on Lite6 models

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,14 @@ The arm itself runs xArm Studio. A developer should be able to use it through th
 }
 ```
 
+## gripper lite
+A two finger gripper compatible with the xarm lite6 model
+```
+{
+   "arm" : "arm"
+}
+```
+
 ## vacuum gripper
 The vacuum gripper only works if it has a wired connection to the not, not a contact connection
 ```

--- a/arm/comm.go
+++ b/arm/comm.go
@@ -862,7 +862,6 @@ func (x *xArm) makeIoControlParamenterCmd(word float32) cmd {
 
 func (x *xArm) liteGripperAction(ctx context.Context, action string) (map[string]interface{}, error) {
 	// we use register 0x7F to control Robot Digital IO to open or close the lite gripper
-	var c cmd
 	var err error
 	switch action {
 	case gripperLiteActionClose:

--- a/arm/comm.go
+++ b/arm/comm.go
@@ -852,59 +852,41 @@ func (x *xArm) grabVacuum(ctx context.Context) error {
 	return nil
 }
 
+func (x *xArm) makeIoControlParamenterCmd(word float32) cmd {
+	arg := make([]byte, 4)
+	binary.LittleEndian.PutUint32(arg, math.Float32bits(word))
+	c := x.vacuumPreamble()
+	c.params = append(c.params, arg...)
+	return c
+}
+
 func (x *xArm) liteGripperAction(ctx context.Context, action string) (map[string]interface{}, error) {
 	// we use register 0x7F to control Robot Digital IO to open or close the lite gripper
 	var c cmd
 	var err error
 	switch action {
 	case gripperLiteActionClose:
-		arg := make([]byte, 4)
-		binary.LittleEndian.PutUint32(arg, math.Float32bits(ioControlParameterWord2High))
-		c = x.vacuumPreamble()
-		c.params = append(c.params, arg...)
-		if _, err = x.send(ctx, c, true); err != nil {
+		if _, err = x.send(ctx, x.makeIoControlParamenterCmd(ioControlParameterWord2High), true); err != nil {
 			return nil, err
 		}
-
-		arg = make([]byte, 4)
-		binary.LittleEndian.PutUint32(arg, math.Float32bits(ioControlParameterWord1Low))
-		c = x.vacuumPreamble()
-		c.params = append(c.params, arg...)
-		if _, err = x.send(ctx, c, true); err != nil {
+		if _, err = x.send(ctx, x.makeIoControlParamenterCmd(ioControlParameterWord1Low), true); err != nil {
 			return nil, err
 		}
 		return map[string]interface{}{}, nil
 	case gripperLiteActionOpen:
-		arg := make([]byte, 4)
-		binary.LittleEndian.PutUint32(arg, math.Float32bits(ioControlParameterWord2Low))
-		c = x.vacuumPreamble()
-		c.params = append(c.params, arg...)
-		if _, err = x.send(ctx, c, true); err != nil {
+		if _, err = x.send(ctx, x.makeIoControlParamenterCmd(ioControlParameterWord2Low), true); err != nil {
 			return nil, err
 		}
 
-		arg = make([]byte, 4)
-		binary.LittleEndian.PutUint32(arg, math.Float32bits(ioControlParameterWord1High))
-		c = x.vacuumPreamble()
-		c.params = append(c.params, arg...)
-		if _, err = x.send(ctx, c, true); err != nil {
+		if _, err = x.send(ctx, x.makeIoControlParamenterCmd(ioControlParameterWord1High), true); err != nil {
 			return nil, err
 		}
 		return map[string]interface{}{}, nil
 	case gripperLiteActionStop:
-		arg := make([]byte, 4)
-		binary.LittleEndian.PutUint32(arg, math.Float32bits(ioControlParameterWord1Low))
-		c = x.vacuumPreamble()
-		c.params = append(c.params, arg...)
-		if _, err = x.send(ctx, c, true); err != nil {
+		if _, err = x.send(ctx, x.makeIoControlParamenterCmd(ioControlParameterWord1Low), true); err != nil {
 			return nil, err
 		}
-
-		arg = make([]byte, 4)
-		binary.LittleEndian.PutUint32(arg, math.Float32bits(ioControlParameterWord2Low))
-		c = x.vacuumPreamble()
-		c.params = append(c.params, arg...)
-		if _, err = x.send(ctx, c, true); err != nil {
+		if _, err = x.send(ctx, x.makeIoControlParamenterCmd(ioControlParameterWord2Low), true); err != nil {
 			return nil, err
 		}
 		return map[string]interface{}{}, nil

--- a/arm/comm.go
+++ b/arm/comm.go
@@ -116,6 +116,13 @@ var regMap = map[string]byte{
 	"VacuumState":    0x80,
 }
 
+const (
+	ioControlParameterWord1High = 257
+	ioControlParameterWord2High = 514
+	ioControlParameterWord1Low  = 256
+	ioControlParameterWord2Low  = 512
+)
+
 type cmd struct {
 	tid    uint16
 	prot   uint16
@@ -843,6 +850,87 @@ func (x *xArm) grabVacuum(ctx context.Context) error {
 		return err
 	}
 	return nil
+}
+
+func (x *xArm) liteGripperAction(ctx context.Context, action string) (map[string]interface{}, error) {
+	// we use register 0x7F to control Robot Digital IO to open or close the lite gripper
+	var c cmd
+	var err error
+	switch action {
+	case gripperLiteActionClose:
+		arg := make([]byte, 4)
+		binary.LittleEndian.PutUint32(arg, math.Float32bits(ioControlParameterWord2High))
+		c = x.vacuumPreamble()
+		c.params = append(c.params, arg...)
+		if _, err = x.send(ctx, c, true); err != nil {
+			return nil, err
+		}
+
+		arg = make([]byte, 4)
+		binary.LittleEndian.PutUint32(arg, math.Float32bits(ioControlParameterWord1Low))
+		c = x.vacuumPreamble()
+		c.params = append(c.params, arg...)
+		if _, err = x.send(ctx, c, true); err != nil {
+			return nil, err
+		}
+		return map[string]interface{}{}, nil
+	case gripperLiteActionOpen:
+		arg := make([]byte, 4)
+		binary.LittleEndian.PutUint32(arg, math.Float32bits(ioControlParameterWord2Low))
+		c = x.vacuumPreamble()
+		c.params = append(c.params, arg...)
+		if _, err = x.send(ctx, c, true); err != nil {
+			return nil, err
+		}
+
+		arg = make([]byte, 4)
+		binary.LittleEndian.PutUint32(arg, math.Float32bits(ioControlParameterWord1High))
+		c = x.vacuumPreamble()
+		c.params = append(c.params, arg...)
+		if _, err = x.send(ctx, c, true); err != nil {
+			return nil, err
+		}
+		return map[string]interface{}{}, nil
+	case gripperLiteActionStop:
+		arg := make([]byte, 4)
+		binary.LittleEndian.PutUint32(arg, math.Float32bits(ioControlParameterWord1Low))
+		c = x.vacuumPreamble()
+		c.params = append(c.params, arg...)
+		if _, err = x.send(ctx, c, true); err != nil {
+			return nil, err
+		}
+
+		arg = make([]byte, 4)
+		binary.LittleEndian.PutUint32(arg, math.Float32bits(ioControlParameterWord2Low))
+		c = x.vacuumPreamble()
+		c.params = append(c.params, arg...)
+		if _, err = x.send(ctx, c, true); err != nil {
+			return nil, err
+		}
+		return map[string]interface{}{}, nil
+	case gripperLiteActionIsClosed:
+		c := x.newCmd(regMap["VacuumState"])
+		additionalParams := []byte{
+			0x09,
+			0x0A,
+			0x18,
+		}
+		c.params = append(c.params, additionalParams...)
+		res, err := x.send(ctx, c, true)
+		if err != nil {
+			return nil, err
+		}
+		if len(res.params) != 5 {
+			return nil, fmt.Errorf("register read 0x18 returned an array of length %d expected length 5 raw data %v", len(res.params), res.params)
+		}
+		isHolding := false
+		if res.params[4] == 2 {
+			isHolding = true
+		}
+		return map[string]interface{}{gripperLiteActionIsClosed: isHolding}, nil
+	}
+
+	return nil, fmt.Errorf("gripper lite action %s is not supported", action)
 }
 
 // Close maps to open in ufactory.

--- a/arm/comm.go
+++ b/arm/comm.go
@@ -921,9 +921,10 @@ func (x *xArm) liteGripperAction(ctx context.Context, action string) (map[string
 			return nil, err
 		}
 		if len(res.params) != 5 {
-			return nil, fmt.Errorf("register read 0x18 returned an array of length %d expected length 5 raw data %v", len(res.params), res.params)
+			return nil, fmt.Errorf("reading status register at address 0x18 returned an array of length %d expected length 5 raw data %v", len(res.params), res.params)
 		}
 		isHolding := false
+		// byte 5 of register 0x18 is 0 when stopped, 1 when opened and 2 when closed
 		if res.params[4] == 2 {
 			isHolding = true
 		}

--- a/arm/comm.go
+++ b/arm/comm.go
@@ -921,7 +921,7 @@ func (x *xArm) liteGripperAction(ctx context.Context, action string) (map[string
 			return nil, err
 		}
 		if len(res.params) != 5 {
-			return nil, fmt.Errorf("reading status register at address 0x18 returned an array of length %d expected length 5 raw data %v", len(res.params), res.params)
+			return nil, fmt.Errorf("status register at address 0x18 returned an array of length %d expected length 5 raw data %v", len(res.params), res.params)
 		}
 		isHolding := false
 		// byte 5 of register 0x18 is 0 when stopped, 1 when opened and 2 when closed

--- a/arm/gripper.go
+++ b/arm/gripper.go
@@ -165,7 +165,7 @@ func (g *myGripperLite) IsMoving(context.Context) (bool, error) {
 }
 
 func (g *myGripperLite) Stop(ctx context.Context, extra map[string]interface{}) error {
-	g.isMoving.Store(false)
+	defer g.isMoving.Store(false)
 	_, err := g.arm.DoCommand(ctx, map[string]interface{}{
 		gripperLiteActionKey: gripperLiteActionStop,
 	})
@@ -181,7 +181,7 @@ func (g *myGripperLite) Geometries(ctx context.Context, _ map[string]interface{}
 
 	clawSize := r3.Vector{X: 20, Y: 48, Z: 25} // size open
 
-	claws, err := spatialmath.NewBox(spatialmath.NewPoseFromPoint(r3.Vector{Z: 27 + (clawSize.Z / -2)}), clawSize, "claws")
+	claws, err := spatialmath.NewBox(spatialmath.NewPoseFromPoint(r3.Vector{Z: caseBoxSize.Z/2 + (clawSize.Z / -2)}), clawSize, "claws")
 	if err != nil {
 		return nil, err
 	}
@@ -226,7 +226,7 @@ func newGripper(ctx context.Context, deps resource.Dependencies, config resource
 
 	g := &myGripper{
 		name:   config.ResourceName(),
-		mf:     referenceframe.NewSimpleModel("foo"),
+		mf:     referenceframe.NewSimpleModel("xarm-gripper"),
 		logger: logger,
 	}
 

--- a/arm/gripper.go
+++ b/arm/gripper.go
@@ -140,7 +140,7 @@ func (g *myGripperLite) IsHoldingSomething(
 	}
 	isHolding, ok := isHoldingRaw.(bool)
 	if !ok {
-		return gripper.HoldingStatus{}, fmt.Errorf("isHolding value is not a bool, %v is a %T", isHoldingRaw, isHoldingRaw)
+		return gripper.HoldingStatus{}, fmt.Errorf("key `%s` value is not a bool, %v is a %T", gripperLiteActionIsClosed, isHoldingRaw, isHoldingRaw)
 	}
 
 	return gripper.HoldingStatus{
@@ -165,8 +165,7 @@ func (g *myGripperLite) IsMoving(context.Context) (bool, error) {
 }
 
 func (g *myGripperLite) Stop(ctx context.Context, extra map[string]interface{}) error {
-	g.isMoving.Store(true)
-	defer g.isMoving.Store(false)
+	g.isMoving.Store(false)
 	_, err := g.arm.DoCommand(ctx, map[string]interface{}{
 		gripperLiteActionKey: gripperLiteActionStop,
 	})

--- a/arm/gripper.go
+++ b/arm/gripper.go
@@ -19,8 +19,19 @@ import (
 	"go.viam.com/utils"
 )
 
-// GripperModel model for the ufactory gripper.
-var GripperModel = family.WithModel("gripper")
+const (
+	// ModelNameGripper is the gripper commonly attached to xArm6/xArm7.
+	ModelNameGripper = "gripper"
+	// ModelNameGripperLite is the gripper commonly attached to the lite6.
+	ModelNameGripperLite = "gripper_lite"
+)
+
+var (
+	// GripperModel model for the ufactory gripper.
+	GripperModel = family.WithModel(ModelNameGripper)
+	// GripperModelLite model for the ufactory gripper-lite.
+	GripperModelLite = family.WithModel(ModelNameGripperLite)
+)
 
 const fullyClosedThreshold = 10
 const fullyOpenThreshold = 830
@@ -46,6 +57,166 @@ func init() {
 		resource.Registration[gripper.Gripper, *GripperConfig]{
 			Constructor: newGripper,
 		})
+	resource.RegisterComponent(
+		gripper.API,
+		GripperModelLite,
+		resource.Registration[gripper.Gripper, *GripperConfig]{
+			Constructor: newGripperLite,
+		})
+}
+
+type myGripperLite struct {
+	resource.AlwaysRebuild
+
+	name resource.Name
+
+	arm      arm.Arm
+	isMoving atomic.Bool
+
+	logger logging.Logger
+}
+
+func newGripperLite(ctx context.Context, deps resource.Dependencies, config resource.Config, logger logging.Logger) (gripper.Gripper, error) {
+	newConf, err := resource.NativeConfig[*GripperConfig](config)
+	if err != nil {
+		return nil, err
+	}
+
+	g := &myGripperLite{
+		name:     config.ResourceName(),
+		logger:   logger,
+		isMoving: atomic.Bool{},
+	}
+
+	g.arm, err = arm.FromDependencies(deps, newConf.Arm)
+	if err != nil {
+		return nil, err
+	}
+
+	return g, nil
+}
+
+func (g *myGripperLite) Grab(ctx context.Context, extra map[string]interface{}) (bool, error) {
+	g.isMoving.Store(true)
+	defer g.isMoving.Store(false)
+	if _, err := g.arm.DoCommand(ctx, map[string]interface{}{
+		gripperLiteActionKey: gripperLiteActionClose,
+	}); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+func (g *myGripperLite) Open(ctx context.Context, extra map[string]interface{}) error {
+	g.isMoving.Store(true)
+	defer g.isMoving.Store(false)
+	_, err := g.arm.DoCommand(ctx, map[string]interface{}{
+		gripperLiteActionKey: gripperLiteActionOpen,
+	})
+	return err
+}
+
+func (g *myGripperLite) IsHoldingSomething(
+	ctx context.Context,
+	extra map[string]interface{},
+) (gripper.HoldingStatus, error) {
+	res, err := g.arm.DoCommand(ctx, map[string]interface{}{
+		gripperLiteActionKey: gripperLiteActionIsClosed,
+	})
+	if err != nil {
+		return gripper.HoldingStatus{}, err
+	}
+	val, ok := res[gripperLiteActionKey]
+	if !ok {
+		return gripper.HoldingStatus{}, fmt.Errorf("command %s didn't return key %s instead got %+v", gripperLiteActionIsClosed, gripperLiteActionKey, res)
+	}
+	converted, ok := val.(map[string]interface{})
+	if !ok {
+		return gripper.HoldingStatus{}, fmt.Errorf("expected map[string]interface{} got %v of type %T", val, val)
+	}
+	isHoldingRaw, ok := converted[gripperLiteActionIsClosed]
+	if !ok {
+		return gripper.HoldingStatus{}, fmt.Errorf("response doesn't contain the key: %s have : %v", gripperLiteActionIsClosed, val)
+	}
+	isHolding, ok := isHoldingRaw.(bool)
+	if !ok {
+		return gripper.HoldingStatus{}, fmt.Errorf("isHolding value is not a bool, %v is a %T", isHoldingRaw, isHoldingRaw)
+	}
+
+	return gripper.HoldingStatus{
+		IsHoldingSomething: isHolding,
+	}, nil
+}
+
+func (g *myGripperLite) Name() resource.Name {
+	return g.name
+}
+
+func (g *myGripperLite) Close(ctx context.Context) error {
+	return g.Stop(ctx, nil)
+}
+
+func (g *myGripperLite) DoCommand(ctx context.Context, cmd map[string]interface{}) (map[string]interface{}, error) {
+	return map[string]interface{}{}, nil
+}
+
+func (g *myGripperLite) IsMoving(context.Context) (bool, error) {
+	return g.isMoving.Load(), nil
+}
+
+func (g *myGripperLite) Stop(ctx context.Context, extra map[string]interface{}) error {
+	g.isMoving.Store(true)
+	defer g.isMoving.Store(false)
+	_, err := g.arm.DoCommand(ctx, map[string]interface{}{
+		gripperLiteActionKey: gripperLiteActionStop,
+	})
+	return err
+}
+
+func (g *myGripperLite) Geometries(ctx context.Context, _ map[string]interface{}) ([]spatialmath.Geometry, error) {
+	caseBoxSize := r3.Vector{X: 30, Y: 60, Z: 55.5}
+	caseBox, err := spatialmath.NewBox(spatialmath.NewPoseFromPoint(r3.Vector{X: 0, Y: 0, Z: caseBoxSize.Z / -2}), caseBoxSize, "case-gripper")
+	if err != nil {
+		return nil, err
+	}
+
+	clawSize := r3.Vector{X: 20, Y: 48, Z: 25} // size open
+
+	claws, err := spatialmath.NewBox(spatialmath.NewPoseFromPoint(r3.Vector{Z: 27 + (clawSize.Z / -2)}), clawSize, "claws")
+	if err != nil {
+		return nil, err
+	}
+
+	return []spatialmath.Geometry{
+		caseBox,
+		claws,
+	}, nil
+}
+
+func (g *myGripperLite) Kinematics(ctx context.Context) (referenceframe.Model, error) {
+	return nil, errors.ErrUnsupported
+}
+
+func (g *myGripperLite) CurrentInputs(ctx context.Context) ([]referenceframe.Input, error) {
+	return nil, errors.ErrUnsupported
+}
+
+func (g *myGripperLite) GoToInputs(ctx context.Context, inputs ...[]referenceframe.Input) error {
+	return errors.ErrUnsupported
+}
+
+type myGripper struct {
+	resource.AlwaysRebuild
+
+	name resource.Name
+	mf   referenceframe.Model
+
+	arm arm.Arm
+
+	goToPositionLock sync.Mutex
+	isMoving         atomic.Bool
+
+	logger logging.Logger
 }
 
 func newGripper(ctx context.Context, deps resource.Dependencies, config resource.Config, logger logging.Logger) (gripper.Gripper, error) {
@@ -66,20 +237,6 @@ func newGripper(ctx context.Context, deps resource.Dependencies, config resource
 	}
 
 	return g, nil
-}
-
-type myGripper struct {
-	resource.AlwaysRebuild
-
-	name resource.Name
-	mf   referenceframe.Model
-
-	arm arm.Arm
-
-	goToPositionLock sync.Mutex
-	isMoving         atomic.Bool
-
-	logger logging.Logger
 }
 
 func (g *myGripper) Grab(ctx context.Context, extra map[string]interface{}) (bool, error) {

--- a/arm/xarm.go
+++ b/arm/xarm.go
@@ -49,6 +49,13 @@ const (
 	getErrorKey              = "get_error"
 	getVacuumGripperStateKey = "get_vacuum_state"
 	vacuumGripperStateKey    = "vacuum_state"
+	gripperLiteActionKey     = "gripper_lite_action"
+
+	// gripperLiteActionKeys.
+	gripperLiteActionOpen     = "open"
+	gripperLiteActionClose    = "close"
+	gripperLiteActionIsClosed = "is_closed"
+	gripperLiteActionStop     = "stop"
 )
 
 //go:embed xarm6_kinematics.json
@@ -492,6 +499,19 @@ func (x *xArm) DoCommand(ctx context.Context, cmd map[string]interface{}) (map[s
 			return nil, err
 		}
 		resp[vacuumGripperStateKey] = res
+		validCommand = true
+	}
+
+	if action, ok := cmd[gripperLiteActionKey]; ok {
+		act, ok := action.(string)
+		if !ok {
+			return nil, fmt.Errorf("action %v (%T) is not a string", action, action)
+		}
+		res, err := x.liteGripperAction(ctx, act)
+		if err != nil {
+			return nil, err
+		}
+		resp[gripperLiteActionKey] = res
 		validCommand = true
 	}
 

--- a/main.go
+++ b/main.go
@@ -15,6 +15,7 @@ func main() {
 		resource.APIModel{API: arm.API, Model: xarm.XArm7Model},
 		resource.APIModel{API: arm.API, Model: xarm.XArmLite6Model},
 		resource.APIModel{API: gripper.API, Model: xarm.GripperModel},
+		resource.APIModel{API: gripper.API, Model: xarm.GripperModelLite},
 		resource.APIModel{API: gripper.API, Model: xarm.VacuumGripperModel},
 	)
 }

--- a/meta.json
+++ b/meta.json
@@ -34,6 +34,12 @@
       "model": "viam:ufactory:vacuum_gripper",
       "markdown_link": "README.md#vacuum-gripper",
       "short_description": "vacuum gripper component driver for the ufactory vacuum gripper"
+    },
+    {
+      "api": "rdk:component:gripper",
+      "model": "viam:ufactory:gripper_lite",
+      "markdown_link": "README.md#gripper-lite",
+      "short_description": "gripper lite component driver for two fingers gripper install on lite6"
     }
   ],
   "build":{


### PR DESCRIPTION
The two finger grippers found on Lite6 arms is pneumatic and cannot be controlled using the `gripper` model. The control works similarly as the vaccum gripper however Grab and open are inverted and state needs to be read from another register.

I think it is best to implement a separate model and driver to correctly supports this type of gripper.