### PR TITLE
Improve servo motor error diagnostics and add reboot DoCommand

### DIFF
--- a/arm/comm.go
+++ b/arm/comm.go
@@ -1189,3 +1189,15 @@ func (x *xArm) setCollisionDetectionSensitivity(ctx context.Context, sensitivity
 	_, err := x.send(ctx, c, true)
 	return err
 }
+
+// reboot sends a reboot command to the controller box and resets the
+// connection. The controller takes ~20-30s to come back up; the next
+// command will trigger reconnection automatically.
+func (x *xArm) reboot(ctx context.Context) error {
+	c := x.newCmd(regMap["Shutdown"])
+	c.params = append(c.params, 2) // 2 = reboot
+	_, err := x.send(ctx, c, false)
+	// Connection will drop; reset so the next call reconnects.
+	x.resetConnection()
+	return err
+}

--- a/arm/comm.go
+++ b/arm/comm.go
@@ -58,13 +58,13 @@ var armBoxErrorMap = map[byte]string{
 	0x01:             "xArm: Emergency Stop Button Pushed In",
 	0x02:             "xArm: Emergency IO Triggered",
 	0x03:             "xArm: Emergency Stop 3-State Switch Pressed",
-	0x0B:             "xArm: Power Cycle Required",
-	0x0C:             "xArm: Power Cycle Required",
-	0x0D:             "xArm: Power Cycle Required",
-	0x0E:             "xArm: Power Cycle Required",
-	0x0F:             "xArm: Power Cycle Required",
-	0x10:             "xArm: Power Cycle Required",
-	0x11:             "xArm: Power Cycle Required",
+	0x0B:             "xArm: Power Cycle Required (Servo Motor 1 Error)",
+	0x0C:             "xArm: Power Cycle Required (Servo Motor 2 Error)",
+	0x0D:             "xArm: Power Cycle Required (Servo Motor 3 Error)",
+	0x0E:             "xArm: Power Cycle Required (Servo Motor 4 Error)",
+	0x0F:             "xArm: Power Cycle Required (Servo Motor 5 Error)",
+	0x10:             "xArm: Power Cycle Required (Servo Motor 6 Error)",
+	0x11:             "xArm: Power Cycle Required (Servo Motor 7 Error)",
 	0x13:             "xArm: Gripper Communication Error",
 	0x15:             "xArm: Kinematic Error",
 	0x16:             "xArm: Self Collision Error",
@@ -185,6 +185,15 @@ func (x *xArm) send(ctx context.Context, c cmd, checkError bool) (cmd, error) {
 			if errCode == 0x25 {
 				return cmd{}, fmt.Errorf("arm is in manual mode: use DoCommand with 'exit_manual_mode' to return to normal operation")
 			}
+			// Servo motor errors (0x0B-0x11) require a power cycle.
+			// Best-effort query for per-servo details with a tight timeout.
+			if errCode >= 0x0B && errCode <= 0x11 {
+				servoCtx, cancel := context.WithTimeout(ctx, 750*time.Millisecond)
+				if servoErr := x.CheckServoErrors(servoCtx); servoErr != nil {
+					x.logger.Debugf("servo error details: %v", servoErr)
+				}
+				cancel()
+			}
 			// Any other errors are cleared automatically by the driver.
 			return cmd{}, decodeError(params)
 		}
@@ -254,9 +263,15 @@ func (x *xArm) CheckServoErrors(ctx context.Context) error {
 	// xArm 6 has 6, xArm 7 has 7, and plus one in the xArm gripper
 	for i := 1; i < 9; i++ {
 		errCode := e.params[i*2]
+		// 0 means no active error for this servo.
+		if errCode == 0 {
+			continue
+		}
 		errMsg, isErr := servoErrorMap[errCode]
 		if isErr {
-			err = multierr.Append(err, errors.New(errMsg))
+			err = multierr.Append(err, fmt.Errorf("servo %d: %s", i, errMsg))
+		} else {
+			err = multierr.Append(err, fmt.Errorf("servo %d: unknown error (code 0x%02X)", i, errCode))
 		}
 	}
 	return err

--- a/arm/xarm.go
+++ b/arm/xarm.go
@@ -57,6 +57,7 @@ const (
 	gripperLiteActionKey     = "gripper_lite_action"
 	enterManualModeKey       = "enter_manual_mode"
 	exitManualModeKey        = "exit_manual_mode"
+	rebootKey                = "reboot"
 
 	// gripperLiteActionKeys.
 	gripperLiteActionOpen     = "open"
@@ -777,6 +778,14 @@ func (x *xArm) DoCommand(ctx context.Context, cmd map[string]any) (map[string]an
 			return nil, err
 		}
 		resp["status"] = "exited manual mode"
+		validCommand = true
+	}
+
+	if _, ok := cmd[rebootKey]; ok {
+		if err := x.reboot(ctx); err != nil {
+			return nil, err
+		}
+		resp["status"] = "rebooting"
 		validCommand = true
 	}
 


### PR DESCRIPTION
## Summary
- Differentiate servo motor error messages (0x0B-0x11) so the caller knows which joint (1-7) requires a power cycle instead of a generic message for all 7
- On servo motor errors, best-effort query `CheckServoErrors` with a 750ms timeout and log per-servo fault details at debug level (e.g., overcurrent, overheat, encoder error)
- Fix bug in `CheckServoErrors` where `errCode == 0x00` (no error) matched a map entry, causing every healthy servo to be falsely reported as "Joint Communication Error"
- Add `reboot` DoCommand that sends register 0x0A (param 2) to reboot the controller box, resets the TCP connection, and returns immediately. The next command reconnects automatically after ~20-30s

## Test plan
- [ ] Trigger a servo motor error on the physical arm and verify the returned error identifies the correct joint number
- [ ] Enable debug logging and verify the per-servo fault detail appears in the log output
- [x] Verify `DoCommand({"reboot": true})` reboots the controller and the arm reconnects on the next command
- [x] Verify no regression on other error codes (collision, e-stop, manual mode)
- [x] Unit tests pass: `go test ./arm/...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)