### PR TITLE
Make ‘set’ non blocking

### DIFF
--- a/arm/comm.go
+++ b/arm/comm.go
@@ -951,11 +951,19 @@ func (x *xArm) gripperSend(ctx context.Context, c cmd) (cmd, error) {
 			return resp, nil
 		}
 		if attempt < gripperRetries-1 {
-			x.logger.Warnf("gripper command failed (attempt %d/%d): %v, retrying", attempt+1, gripperRetries, err)
+			x.logger.Warnf("gripper command failed (attempt %d/%d): %v, re-initializing gripper", attempt+1, gripperRetries, err)
+			// Clear the arm error state.
 			if clearErr := x.checkReadyState(ctx, false); clearErr != nil {
 				x.logger.Warnf("failed to clear error state during gripper retry: %v", clearErr)
 			}
-			time.Sleep(100 * time.Millisecond)
+			// Invalidate cached gripper state and re-enable the gripper.
+			// The xArm Python SDK does the same: on C19 it sets gripper_is_enabled=False
+			// so the next command re-runs enable + set_mode before the actual operation.
+			x.gripperSetup.Store(false)
+			if setupErr := x.setupGripper(ctx); setupErr != nil {
+				x.logger.Warnf("failed to re-initialize gripper during retry: %v", setupErr)
+			}
+			time.Sleep(250 * time.Millisecond)
 		}
 	}
 	return resp, err
@@ -979,7 +987,7 @@ func (x *xArm) enableGripper(ctx context.Context) error {
 	c.params = append(c.params, 0x00, 0x01)
 	c.params = append(c.params, 0x02)
 	c.params = append(c.params, 0x00, 0x01)
-	_, err := x.gripperSend(ctx, c)
+	_, err := x.send(ctx, c, true)
 	return err
 }
 
@@ -993,7 +1001,7 @@ func (x *xArm) setGripperMode(ctx context.Context, speed bool) error {
 	} else {
 		c.params = append(c.params, 0x00, 0x00)
 	}
-	_, err := x.gripperSend(ctx, c)
+	_, err := x.send(ctx, c, true)
 	return err
 }
 

--- a/arm/comm.go
+++ b/arm/comm.go
@@ -955,19 +955,21 @@ func (x *xArm) gripperSend(ctx context.Context, c cmd) (cmd, error) {
 			return resp, nil
 		}
 		if attempt < gripperRetries-1 {
-			x.logger.Warnf("gripper command failed (attempt %d/%d): %v, re-initializing gripper", attempt+1, gripperRetries, err)
-			// Clear the arm error state.
-			if clearErr := x.checkReadyState(ctx, false); clearErr != nil {
-				x.logger.Warnf("failed to clear error state during gripper retry: %v", clearErr)
+			x.logger.Warnf("gripper command failed (attempt %d/%d): %v, performing e-stop recovery", attempt+1, gripperRetries, err)
+			// Replicate the manual e-stop + re-enable cycle that reliably restores
+			// gripper communication. ClearError alone doesn't reset the TGPIO Modbus
+			// interface — setMotionState(4) ("restart system") does.
+			if stopErr := x.setMotionState(ctx, 4); stopErr != nil {
+				x.logger.Warnf("e-stop during gripper recovery failed: %v", stopErr)
 			}
-			// Invalidate cached gripper state and re-enable the gripper.
-			// The xArm Python SDK does the same: on C19 it sets gripper_is_enabled=False
-			// so the next command re-runs enable + set_mode before the actual operation.
+			time.Sleep(500 * time.Millisecond)
 			x.gripperSetup.Store(false)
-			if setupErr := x.setupGripper(ctx); setupErr != nil {
-				x.logger.Warnf("failed to re-initialize gripper during retry: %v", setupErr)
+			if startErr := x.start(ctx, false); startErr != nil {
+				x.logger.Warnf("re-enable during gripper recovery failed: %v", startErr)
 			}
-			time.Sleep(250 * time.Millisecond)
+			if setupErr := x.setupGripper(ctx); setupErr != nil {
+				x.logger.Warnf("gripper re-init during recovery failed: %v", setupErr)
+			}
 		}
 	}
 	return resp, err

--- a/arm/comm.go
+++ b/arm/comm.go
@@ -983,19 +983,21 @@ func (x *xArm) gripperSend(ctx context.Context, c cmd) (cmd, error) {
 			return resp, nil
 		}
 		if attempt < gripperRetries-1 {
-			x.logger.Warnf("gripper command failed (attempt %d/%d): %v, re-initializing gripper", attempt+1, gripperRetries, err)
-			// Clear the arm error state.
-			if clearErr := x.checkReadyState(ctx, false); clearErr != nil {
-				x.logger.Warnf("failed to clear error state during gripper retry: %v", clearErr)
+			x.logger.Warnf("gripper command failed (attempt %d/%d): %v, performing e-stop recovery", attempt+1, gripperRetries, err)
+			// Replicate the manual e-stop + re-enable cycle that reliably restores
+			// gripper communication. ClearError alone doesn't reset the TGPIO Modbus
+			// interface — setMotionState(4) ("restart system") does.
+			if stopErr := x.setMotionState(ctx, 4); stopErr != nil {
+				x.logger.Warnf("e-stop during gripper recovery failed: %v", stopErr)
 			}
-			// Invalidate cached gripper state and re-enable the gripper.
-			// The xArm Python SDK does the same: on C19 it sets gripper_is_enabled=False
-			// so the next command re-runs enable + set_mode before the actual operation.
+			time.Sleep(500 * time.Millisecond)
 			x.gripperSetup.Store(false)
-			if setupErr := x.setupGripper(ctx); setupErr != nil {
-				x.logger.Warnf("failed to re-initialize gripper during retry: %v", setupErr)
+			if startErr := x.start(ctx, false); startErr != nil {
+				x.logger.Warnf("re-enable during gripper recovery failed: %v", startErr)
 			}
-			time.Sleep(250 * time.Millisecond)
+			if setupErr := x.setupGripper(ctx); setupErr != nil {
+				x.logger.Warnf("gripper re-init during recovery failed: %v", setupErr)
+			}
 		}
 	}
 	return resp, err

--- a/arm/comm.go
+++ b/arm/comm.go
@@ -275,7 +275,6 @@ func (x *xArm) checkReadyState(ctx context.Context, enableMotion bool) error {
 	if currentState[0]&errorState != 0 {
 		// we assume that if we run into an error we will need to restart the servos etc.
 		x.started.Store(-1)
-		x.gripperSetup.Store(false)
 
 		// we are in error state, we will attempt to clear the error
 		// if we fail we will return the error code
@@ -941,6 +940,27 @@ func (x *xArm) setupGripper(ctx context.Context) error {
 	return nil
 }
 
+const gripperRetries = 3
+
+func (x *xArm) gripperSend(ctx context.Context, c cmd) (cmd, error) {
+	var resp cmd
+	var err error
+	for attempt := range gripperRetries {
+		resp, err = x.send(ctx, c, true)
+		if err == nil {
+			return resp, nil
+		}
+		if attempt < gripperRetries-1 {
+			x.logger.Warnf("gripper command failed (attempt %d/%d): %v, retrying", attempt+1, gripperRetries, err)
+			if clearErr := x.checkReadyState(ctx, false); clearErr != nil {
+				x.logger.Warnf("failed to clear error state during gripper retry: %v", clearErr)
+			}
+			time.Sleep(100 * time.Millisecond)
+		}
+	}
+	return resp, err
+}
+
 func (x *xArm) gripperPreamble(write bool) cmd {
 	c := x.newCmd(regMap["GripperControl"])
 	c.params = append(c.params, 0x09) // host id
@@ -959,7 +979,7 @@ func (x *xArm) enableGripper(ctx context.Context) error {
 	c.params = append(c.params, 0x00, 0x01)
 	c.params = append(c.params, 0x02)
 	c.params = append(c.params, 0x00, 0x01)
-	_, err := x.send(ctx, c, true)
+	_, err := x.gripperSend(ctx, c)
 	return err
 }
 
@@ -973,7 +993,7 @@ func (x *xArm) setGripperMode(ctx context.Context, speed bool) error {
 	} else {
 		c.params = append(c.params, 0x00, 0x00)
 	}
-	_, err := x.send(ctx, c, true)
+	_, err := x.gripperSend(ctx, c)
 	return err
 }
 
@@ -986,7 +1006,7 @@ func (x *xArm) setGripperPosition(ctx context.Context, position uint32) error {
 	binary.BigEndian.PutUint32(tmpBytes, position)
 	x.logger.Debugf("setGripperPosition bytes: %v", tmpBytes)
 	c.params = append(c.params, tmpBytes...)
-	_, err := x.send(ctx, c, true)
+	_, err := x.gripperSend(ctx, c)
 	return err
 }
 
@@ -999,7 +1019,7 @@ func (x *xArm) setGripperSpeed(ctx context.Context, speed uint16) error {
 	binary.BigEndian.PutUint16(tmpBytes, speed)
 	x.logger.Debugf("setGripperSpeed bytes: %v", tmpBytes)
 	c.params = append(c.params, tmpBytes...)
-	_, err := x.send(ctx, c, true)
+	_, err := x.gripperSend(ctx, c)
 	return err
 }
 
@@ -1007,7 +1027,7 @@ func (x *xArm) getGripperSpeed(ctx context.Context) (uint16, error) {
 	c := x.gripperPreamble(false)
 	c.params = append(c.params, 0x03, 0x03)
 	c.params = append(c.params, 0x00, 0x01)
-	res, err := x.send(ctx, c, true)
+	res, err := x.gripperSend(ctx, c)
 	if err != nil {
 		return 0, err
 	}
@@ -1025,7 +1045,7 @@ func (x *xArm) getGripperPosition(ctx context.Context) (int32, error) {
 	c := x.gripperPreamble(false)
 	c.params = append(c.params, 0x07, 0x02)
 	c.params = append(c.params, 0x00, 0x02)
-	res, err := x.send(ctx, c, true)
+	res, err := x.gripperSend(ctx, c)
 	if err != nil {
 		return 0, err
 	}

--- a/arm/comm.go
+++ b/arm/comm.go
@@ -979,11 +979,19 @@ func (x *xArm) gripperSend(ctx context.Context, c cmd) (cmd, error) {
 			return resp, nil
 		}
 		if attempt < gripperRetries-1 {
-			x.logger.Warnf("gripper command failed (attempt %d/%d): %v, retrying", attempt+1, gripperRetries, err)
+			x.logger.Warnf("gripper command failed (attempt %d/%d): %v, re-initializing gripper", attempt+1, gripperRetries, err)
+			// Clear the arm error state.
 			if clearErr := x.checkReadyState(ctx, false); clearErr != nil {
 				x.logger.Warnf("failed to clear error state during gripper retry: %v", clearErr)
 			}
-			time.Sleep(100 * time.Millisecond)
+			// Invalidate cached gripper state and re-enable the gripper.
+			// The xArm Python SDK does the same: on C19 it sets gripper_is_enabled=False
+			// so the next command re-runs enable + set_mode before the actual operation.
+			x.gripperSetup.Store(false)
+			if setupErr := x.setupGripper(ctx); setupErr != nil {
+				x.logger.Warnf("failed to re-initialize gripper during retry: %v", setupErr)
+			}
+			time.Sleep(250 * time.Millisecond)
 		}
 	}
 	return resp, err
@@ -995,7 +1003,7 @@ func (x *xArm) enableGripper(ctx context.Context) error {
 	c.params = append(c.params, 0x00, 0x01)
 	c.params = append(c.params, 0x02)
 	c.params = append(c.params, 0x00, 0x01)
-	_, err := x.gripperSend(ctx, c)
+	_, err := x.send(ctx, c, true)
 	return err
 }
 
@@ -1009,7 +1017,7 @@ func (x *xArm) setGripperMode(ctx context.Context, speed bool) error {
 	} else {
 		c.params = append(c.params, 0x00, 0x00)
 	}
-	_, err := x.gripperSend(ctx, c)
+	_, err := x.send(ctx, c, true)
 	return err
 }
 

--- a/arm/comm.go
+++ b/arm/comm.go
@@ -198,8 +198,12 @@ func (m *modbusConn) writeBytes(ctx context.Context, c cmd) (cmd, error) {
 	return m.responseInLock(ctx)
 }
 
-func (m *modbusConn) responseInLock(ctx context.Context) (cmd, error) {
-	buf, err := utils.ReadBytes(ctx, m.conn, 7)
+func (m *modbusConn) responseInLock(_ context.Context) (cmd, error) {
+	// Use a non-cancellable context for reading the response. Once a command has been
+	// written to the socket, we must read the response to keep the protocol in sync.
+	// The 5-second TCP deadline set in writeBytes provides timeout protection.
+	readCtx := context.WithoutCancel(context.Background())
+	buf, err := utils.ReadBytes(readCtx, m.conn, 7)
 	if err != nil {
 		m.resetConnection()
 		return cmd{}, err
@@ -209,7 +213,7 @@ func (m *modbusConn) responseInLock(ctx context.Context) (cmd, error) {
 	c.prot = binary.BigEndian.Uint16(buf[2:4])
 	c.reg = buf[6]
 	length := binary.BigEndian.Uint16(buf[4:6])
-	c.params, err = utils.ReadBytes(ctx, m.conn, int(length-1))
+	c.params, err = utils.ReadBytes(readCtx, m.conn, int(length-1))
 	if err != nil {
 		m.resetConnection()
 		return cmd{}, err

--- a/arm/comm.go
+++ b/arm/comm.go
@@ -296,7 +296,6 @@ func (x *xArm) checkReadyState(ctx context.Context, enableMotion bool) error {
 	if currentState[0]&errorState != 0 {
 		// we assume that if we run into an error we will need to restart the servos etc.
 		x.started.Store(-1)
-		x.gripperSetup.Store(false)
 
 		// we are in error state, we will attempt to clear the error
 		// if we fail we will return the error code
@@ -962,14 +961,32 @@ func (x *xArm) gripperPreamble(write bool) cmd {
 	return c
 }
 
-// gripperSend mirrors x.send but routes through gripperConn. checkError is
-// always true on this path — gripper Modbus failures should surface, never
-// be swallowed silently.
+const gripperRetries = 3
+
+// gripperSend mirrors x.send but routes through gripperConn, retrying a few
+// times on failure and clearing the arm's error state between attempts.
+// checkError is always true on this path — gripper Modbus failures should
+// surface, never be swallowed silently.
 func (x *xArm) gripperSend(ctx context.Context, c cmd) (cmd, error) {
 	if x.closed.Load() {
 		return cmd{}, errors.New("closed")
 	}
-	return x.gripperConn.send(ctx, c, true)
+	var resp cmd
+	var err error
+	for attempt := range gripperRetries {
+		resp, err = x.gripperConn.send(ctx, c, true)
+		if err == nil {
+			return resp, nil
+		}
+		if attempt < gripperRetries-1 {
+			x.logger.Warnf("gripper command failed (attempt %d/%d): %v, retrying", attempt+1, gripperRetries, err)
+			if clearErr := x.checkReadyState(ctx, false); clearErr != nil {
+				x.logger.Warnf("failed to clear error state during gripper retry: %v", clearErr)
+			}
+			time.Sleep(100 * time.Millisecond)
+		}
+	}
+	return resp, err
 }
 
 func (x *xArm) enableGripper(ctx context.Context) error {

--- a/arm/comm.go
+++ b/arm/comm.go
@@ -275,6 +275,7 @@ func (x *xArm) checkReadyState(ctx context.Context, enableMotion bool) error {
 	if currentState[0]&errorState != 0 {
 		// we assume that if we run into an error we will need to restart the servos etc.
 		x.started.Store(-1)
+		x.gripperSetup.Store(false)
 
 		// we are in error state, we will attempt to clear the error
 		// if we fail we will return the error code
@@ -484,6 +485,7 @@ func (x *xArm) Close(ctx context.Context) error {
 
 	x.conn = nil
 	x.closed.Store(true)
+	x.gripperSetup.Store(false)
 
 	return err
 }
@@ -926,12 +928,16 @@ func (x *xArm) IsMoving(ctx context.Context) (bool, error) {
 }
 
 func (x *xArm) setupGripper(ctx context.Context) error {
+	if x.gripperSetup.Load() {
+		return nil
+	}
 	if err := x.enableGripper(ctx); err != nil {
 		return err
 	}
 	if err := x.setGripperMode(ctx, false); err != nil {
 		return err
 	}
+	x.gripperSetup.Store(true)
 	return nil
 }
 

--- a/arm/comm.go
+++ b/arm/comm.go
@@ -218,8 +218,12 @@ func (x *xArm) writeBytes(ctx context.Context, c cmd) (cmd, error) {
 	return x.responseInLock(ctx)
 }
 
-func (x *xArm) responseInLock(ctx context.Context) (cmd, error) {
-	buf, err := utils.ReadBytes(ctx, x.conn, 7)
+func (x *xArm) responseInLock(_ context.Context) (cmd, error) {
+	// Use a non-cancellable context for reading the response. Once a command has been
+	// written to the socket, we must read the response to keep the protocol in sync.
+	// The 5-second TCP deadline set in writeBytes provides timeout protection.
+	readCtx := context.WithoutCancel(context.Background())
+	buf, err := utils.ReadBytes(readCtx, x.conn, 7)
 	if err != nil {
 		x.resetConnection()
 		return cmd{}, err
@@ -229,7 +233,7 @@ func (x *xArm) responseInLock(ctx context.Context) (cmd, error) {
 	c.prot = binary.BigEndian.Uint16(buf[2:4])
 	c.reg = buf[6]
 	length := binary.BigEndian.Uint16(buf[4:6])
-	c.params, err = utils.ReadBytes(ctx, x.conn, int(length-1))
+	c.params, err = utils.ReadBytes(readCtx, x.conn, int(length-1))
 	if err != nil {
 		x.resetConnection()
 		return cmd{}, err

--- a/arm/comm.go
+++ b/arm/comm.go
@@ -296,6 +296,7 @@ func (x *xArm) checkReadyState(ctx context.Context, enableMotion bool) error {
 	if currentState[0]&errorState != 0 {
 		// we assume that if we run into an error we will need to restart the servos etc.
 		x.started.Store(-1)
+		x.gripperSetup.Store(false)
 
 		// we are in error state, we will attempt to clear the error
 		// if we fail we will return the error code
@@ -489,6 +490,7 @@ func (x *xArm) Close(ctx context.Context) error {
 	}
 
 	x.closed.Store(true)
+	x.gripperSetup.Store(false)
 
 	return err
 }
@@ -931,12 +933,16 @@ func (x *xArm) IsMoving(ctx context.Context) (bool, error) {
 }
 
 func (x *xArm) setupGripper(ctx context.Context) error {
+	if x.gripperSetup.Load() {
+		return nil
+	}
 	if err := x.enableGripper(ctx); err != nil {
 		return err
 	}
 	if err := x.setGripperMode(ctx, false); err != nil {
 		return err
 	}
+	x.gripperSetup.Store(true)
 	return nil
 }
 

--- a/arm/gripper.go
+++ b/arm/gripper.go
@@ -372,11 +372,9 @@ func (g *myGripper) DoCommand(ctx context.Context, cmd map[string]any) (map[stri
 	}
 	if posF, ok := cmd["set"].(float64); ok {
 		pos := int(posF)
-		_, err := g.goToPosition(ctx, pos)
-		if err != nil {
-			return nil, err
-		}
-		pos, err = g.getPosition(ctx)
+		_, err := g.arm.DoCommand(ctx, map[string]any{
+			"move_gripper": float64(pos),
+		})
 		if err != nil {
 			return nil, err
 		}

--- a/arm/gripper.go
+++ b/arm/gripper.go
@@ -318,7 +318,12 @@ func (g *myGripper) goToPosition(ctx context.Context, goal int) (int, error) {
 
 		pos, err := g.getPosition(ctx)
 		if err != nil {
-			return 0, err
+			// Retry once after a brief delay to handle transient C19 errors.
+			time.Sleep(100 * time.Millisecond)
+			pos, err = g.getPosition(ctx)
+			if err != nil {
+				return 0, err
+			}
 		}
 
 		if math.Abs(float64(pos-goal)) <= 6 {

--- a/arm/gripper.go
+++ b/arm/gripper.go
@@ -358,11 +358,9 @@ func (g *myGripper) DoCommand(ctx context.Context, cmd map[string]any) (map[stri
 	}
 	if posF, ok := cmd["set"].(float64); ok {
 		pos := int(posF)
-		_, err := g.goToPosition(ctx, pos)
-		if err != nil {
-			return nil, err
-		}
-		pos, err = g.getPosition(ctx)
+		_, err := g.arm.DoCommand(ctx, map[string]any{
+			"move_gripper": float64(pos),
+		})
 		if err != nil {
 			return nil, err
 		}

--- a/arm/gripper.go
+++ b/arm/gripper.go
@@ -306,7 +306,12 @@ func (g *myGripper) goToPosition(ctx context.Context, goal int) (int, error) {
 
 		pos, err := g.getPosition(ctx)
 		if err != nil {
-			return 0, err
+			// Retry once after a brief delay to handle transient C19 errors.
+			time.Sleep(100 * time.Millisecond)
+			pos, err = g.getPosition(ctx)
+			if err != nil {
+				return 0, err
+			}
 		}
 
 		if math.Abs(float64(pos-goal)) <= 6 {

--- a/arm/xarm.go
+++ b/arm/xarm.go
@@ -143,7 +143,8 @@ type xArm struct {
 	gripperConn *modbusConn
 
 	// state of movement things
-	started atomic.Int32 // -1 is off, >= 0 is mode
+	started      atomic.Int32 // -1 is off, >= 0 is mode
+	gripperSetup atomic.Bool  // true if gripper has been enabled and mode set
 
 	name        resource.Name
 	conf        *Config
@@ -385,7 +386,10 @@ func NewXArm(ctx context.Context, name resource.Name,
 		acceleration: utils.DegToRad(float64(newConf.acceleration())),
 		speed:        utils.DegToRad(float64(newConf.speed())),
 	}
-	x.cmdConn = newModbusConn(newConf.host(), logger, func() { x.started.Store(-1) })
+	x.cmdConn = newModbusConn(newConf.host(), logger, func() {
+		x.started.Store(-1)
+		x.gripperSetup.Store(false)
+	})
 	x.gripperConn = x.cmdConn // overwritten below if port 503 connects
 
 	if newConf.Motion != "" {

--- a/arm/xarm.go
+++ b/arm/xarm.go
@@ -139,8 +139,9 @@ type xArm struct {
 	moveLock sync.Mutex
 
 	// state of movement things
-	started atomic.Int32 // -1 is off, >= 0 is mode
-	tid     uint16
+	started      atomic.Int32 // -1 is off, >= 0 is mode
+	gripperSetup atomic.Bool  // true if gripper has been enabled and mode set
+	tid          uint16
 
 	name        resource.Name
 	conf        *Config
@@ -587,6 +588,7 @@ func (x *xArm) resetConnection() {
 	}
 	x.conn = nil
 	x.started.Store(-1)
+	x.gripperSetup.Store(false)
 }
 
 func (x *xArm) connect(ctx context.Context) error {


### PR DESCRIPTION
for vive teleop i noticed i couldn’t cancel a `set` command that was inflight in favor of a newer more desired position. This change makes set fire and forget, so that you can send in new set commands before the previous one finishes executing. the ufactory firmware handles this nicely and starts moving towards the most recent position set in.