### PR TITLE
fix load do command error when using vaccum gripper

### DIFF
--- a/arm/xarm.go
+++ b/arm/xarm.go
@@ -725,9 +725,6 @@ func (x *xArm) DoCommand(ctx context.Context, cmd map[string]any) (map[string]an
 	}
 
 	if _, ok := cmd[loadKey]; ok {
-		if err := x.setupGripper(ctx); err != nil {
-			return nil, err
-		}
 		loadInformation, err := x.getLoad(ctx)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
                                                           
  Remove setupGripper call from the load DoCommand handler:                                     
  - setupGripper sends commands to the standard gripper which causes a gripper  communication error on arms using the vacuum gripper           
  -  tested that torque readings are identical with and without calling setupGripper with the standard gripper