### PR TITLE
Persistent host network setup for Linux + startup hint

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ The service receives the arm's current position prepended to the requested waypo
 
 The trajectory is sampled at the arm's configured `move_hz` frequency (default 100 Hz).
 
-#### Connecting using macOS
+### Connecting using macOS
 The following steps can be followed when running viam-server on your mac.
 1. Connect an ethernet cable between the Arm's control box and a USB-C hub/adapter connected to your mac.
 1. Open "System Setting" -> "Network"
@@ -83,21 +83,34 @@ The following steps can be followed when running viam-server on your mac.
 1. Click OK to save the changes.
 1. Your mac should now be able to connect to the xArm, and you can verify with `ping <host>` to the arm's IP address. Note that the IP address setup in your mac's networking settings is not the ping address and should not be used in Viam configuration. It was only set to establish a network to talk to the arm on the IP address that is specified on the control box.
 
-#### Connecting using a Raspberry Pi
-The following steps may need to be followed when running viam-server on your pi.
+### Connecting using Linux
 
+When `viam-server` runs on Linux (Raspberry Pi, Ubuntu, Debian, Fedora/RHEL), the host needs a static IP on the arm's subnet (`192.168.1.0/24` by factory default) that persists across reboots. A helper script in this repo handles the full setup:
 
-1. Connect an Ethernet cable from the xArm's control box to the Pi.
-2. Open a terminal on the Pi.
-3. Assign the Pi an IP address on the same subnet as the arm. For example, if the xArm’s IP is `192.168.1.2`, you can use:
 ```bash
-sudo ip addr add 192.168.1.10/24 dev eth0
-sudo ip link set eth0 up
+curl -fsSL https://raw.githubusercontent.com/viam-modules/viam-ufactory-xarm/main/tools/setup-arm-link.sh \
+  | sudo bash
 ```
-4. Verify connectivity by pinging the xArm:
+
+With no arguments the script auto-detects the host's ethernet interface and assigns `192.168.1.10/24`. Override with flags if needed:
+
 ```bash
-ping 192.168.1.2
+curl -fsSL https://raw.githubusercontent.com/viam-modules/viam-ufactory-xarm/main/tools/setup-arm-link.sh \
+  | sudo bash -s -- --iface eth0 --host-ip 192.168.1.20
 ```
+
+Add `--dry-run` to preview without applying. The script supports NetworkManager (Ubuntu Desktop, Raspberry Pi OS Bookworm+, Fedora/RHEL, Debian Desktop) and netplan (Ubuntu Server), and binds the resulting profile to the NIC's MAC address so it survives if the interface is ever renamed.
+
+Verify reachability (replace with the IP on your control box sticker):
+
+```bash
+ping -c 3 192.168.1.203
+```
+
+To remove the profile later:
+
+- NetworkManager: `sudo nmcli connection delete xarm-link`
+- netplan: `sudo rm /etc/netplan/99-xarm-link.yaml && sudo netplan apply`
 
 ### Using within a Frame System
 

--- a/arm/network_hint.go
+++ b/arm/network_hint.go
@@ -1,0 +1,55 @@
+package arm
+
+import (
+	"fmt"
+	"net"
+	"runtime"
+
+	"go.viam.com/rdk/logging"
+)
+
+// warnIfArmSubnetUnreachable logs a setup hint if no local network interface
+// has an address on the same /24 as armHost. Linux only, since the script it
+// points at is Linux-specific. Silent on macOS/Windows and on hostname (non-IP)
+// hosts, to avoid false positives.
+func warnIfArmSubnetUnreachable(logger logging.Logger, armHost string) {
+	if runtime.GOOS != "linux" {
+		return
+	}
+	armIP4 := net.ParseIP(armHost).To4()
+	if armIP4 == nil {
+		return
+	}
+	ifaces, err := net.Interfaces()
+	if err != nil {
+		return
+	}
+	for _, iface := range ifaces {
+		addrs, aerr := iface.Addrs()
+		if aerr != nil {
+			continue
+		}
+		for _, addr := range addrs {
+			ipNet, ok := addr.(*net.IPNet)
+			if !ok {
+				continue
+			}
+			ip4 := ipNet.IP.To4()
+			if ip4 == nil {
+				continue
+			}
+			if ip4[0] == armIP4[0] && ip4[1] == armIP4[1] && ip4[2] == armIP4[2] {
+				return
+			}
+		}
+	}
+	subnet := fmt.Sprintf("%d.%d.%d.0/24", armIP4[0], armIP4[1], armIP4[2])
+	logger.Warnf(
+		"host has no network interface on the arm's subnet %s (arm host %s); "+
+			"the module will fail to connect until the host NIC has a static IP on that subnet. "+
+			"Run on this host to configure a persistent static IP:\n"+
+			"    curl -fsSL https://raw.githubusercontent.com/viam-modules/viam-ufactory-xarm/main/tools/setup-arm-link.sh | sudo bash\n"+
+			"See: https://github.com/viam-modules/viam-ufactory-xarm#connecting-using-linux",
+		subnet, armHost,
+	)
+}

--- a/arm/xarm.go
+++ b/arm/xarm.go
@@ -417,6 +417,8 @@ func NewXArm(ctx context.Context, name resource.Name,
 		}
 	}
 
+	warnIfArmSubnetUnreachable(logger, newConf.Host)
+
 	err = x.connect(ctx)
 	if err != nil {
 		return nil, err

--- a/tools/setup-arm-link.sh
+++ b/tools/setup-arm-link.sh
@@ -1,0 +1,237 @@
+#!/usr/bin/env bash
+#
+# setup-arm-link.sh — configure a persistent static IP on the host's NIC
+# so it can reach the UFactory xArm controller across reboots.
+#
+# Supports hosts managed by NetworkManager (Ubuntu Desktop, Raspberry Pi OS
+# Bookworm+, Fedora/RHEL, Debian Desktop) and by netplan/systemd-networkd
+# (Ubuntu Server). The resulting profile is bound to the NIC's MAC address
+# so it survives across interface-name changes (e.g. enp86s0 vs eno1).
+
+set -euo pipefail
+
+HOST_IP="192.168.1.10"
+PREFIX="24"
+IFACE=""
+DRY_RUN=0
+CON_NAME="xarm-link"
+NETPLAN_FILE="/etc/netplan/99-xarm-link.yaml"
+
+log() { printf '[setup-arm-link] %s\n' "$*"; }
+err() { printf '[setup-arm-link] ERROR: %s\n' "$*" >&2; }
+
+usage() {
+    cat <<'EOF'
+Usage: sudo bash setup-arm-link.sh [options]
+
+Configure a persistent static IP on the host's NIC for the xArm link.
+
+Options:
+  --iface NAME     Interface to configure (default: auto-detect)
+  --host-ip IP     Host IP on the arm subnet (default: 192.168.1.10)
+  --prefix N       Subnet prefix length (default: 24)
+  --dry-run        Print what would happen, don't apply
+  -h, --help       Show this help
+
+Remove later:
+  NetworkManager:  sudo nmcli connection delete xarm-link
+  netplan:         sudo rm /etc/netplan/99-xarm-link.yaml && sudo netplan apply
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --iface)   IFACE="${2:-}";   shift 2 ;;
+        --host-ip) HOST_IP="${2:-}"; shift 2 ;;
+        --prefix)  PREFIX="${2:-}";  shift 2 ;;
+        --dry-run) DRY_RUN=1;        shift ;;
+        -h|--help) usage; exit 0 ;;
+        *) err "unknown argument: $1"; usage >&2; exit 2 ;;
+    esac
+done
+
+require_root() {
+    if [[ $EUID -ne 0 ]]; then
+        err "must run as root (use sudo)"
+        exit 1
+    fi
+}
+
+detect_iface() {
+    local candidates=() name
+    for path in /sys/class/net/*; do
+        name=$(basename "$path")
+        case "$name" in
+            lo|docker*|virbr*|veth*|br-*|tun*|tap*|bond*|wl*|wlx*|wwan*|ppp*) continue ;;
+        esac
+        [[ -e "$path/device" ]] || continue
+        candidates+=("$name")
+    done
+
+    if [[ ${#candidates[@]} -eq 0 ]]; then
+        err "no physical ethernet interfaces found; pass --iface explicitly"
+        exit 1
+    fi
+
+    local preferred=()
+    for name in "${candidates[@]}"; do
+        local has_ip4
+        has_ip4=$(ip -o -4 addr show dev "$name" 2>/dev/null | wc -l)
+        if [[ "$has_ip4" -eq 0 ]]; then
+            preferred+=("$name")
+        fi
+    done
+
+    local -a pool
+    if [[ ${#preferred[@]} -gt 0 ]]; then
+        pool=("${preferred[@]}")
+    else
+        pool=("${candidates[@]}")
+    fi
+
+    if [[ ${#pool[@]} -eq 1 ]]; then
+        printf '%s' "${pool[0]}"
+        return 0
+    fi
+
+    err "multiple candidate interfaces found: ${pool[*]}"
+    err "pass --iface to pick one explicitly"
+    exit 1
+}
+
+get_mac() {
+    cat "/sys/class/net/$1/address"
+}
+
+detect_stack() {
+    if command -v nmcli >/dev/null 2>&1 && systemctl is-active --quiet NetworkManager 2>/dev/null; then
+        echo "nm"
+    elif command -v netplan >/dev/null 2>&1 && [[ -d /etc/netplan ]]; then
+        echo "netplan"
+    else
+        echo "unknown"
+    fi
+}
+
+apply_nm() {
+    local iface="$1" mac="$2" host_ip="$3" prefix="$4"
+
+    if [[ $DRY_RUN -eq 1 ]]; then
+        cat <<EOF
+[dry-run] would run:
+  nmcli connection delete $CON_NAME      # if it already exists
+  nmcli connection add type ethernet con-name $CON_NAME mac $mac \\
+      ipv4.method manual ipv4.addresses $host_ip/$prefix \\
+      ipv4.never-default yes ipv4.ignore-auto-dns yes \\
+      ipv6.method disabled connection.autoconnect yes
+  nmcli connection up $CON_NAME
+EOF
+        return 0
+    fi
+
+    log "configuring NetworkManager profile '$CON_NAME' on $iface (MAC $mac) → $host_ip/$prefix"
+
+    if nmcli -t -f NAME connection show | grep -qx "$CON_NAME"; then
+        log "replacing existing profile '$CON_NAME'"
+        nmcli connection delete "$CON_NAME" >/dev/null
+    fi
+
+    nmcli connection add \
+        type ethernet \
+        con-name "$CON_NAME" \
+        mac "$mac" \
+        ipv4.method manual \
+        ipv4.addresses "$host_ip/$prefix" \
+        ipv4.never-default yes \
+        ipv4.ignore-auto-dns yes \
+        ipv6.method disabled \
+        connection.autoconnect yes >/dev/null
+
+    nmcli connection up "$CON_NAME" >/dev/null
+}
+
+apply_netplan() {
+    local iface="$1" mac="$2" host_ip="$3" prefix="$4"
+
+    local yaml
+    yaml=$(cat <<EOF
+network:
+  version: 2
+  ethernets:
+    xarm-link:
+      match:
+        macaddress: $mac
+      dhcp4: false
+      dhcp6: false
+      link-local: []
+      accept-ra: false
+      addresses: [$host_ip/$prefix]
+      optional: true
+EOF
+    )
+
+    if [[ $DRY_RUN -eq 1 ]]; then
+        echo "[dry-run] would write $NETPLAN_FILE (mode 0600, root:root):"
+        printf '%s\n' "$yaml"
+        echo "[dry-run] then run: netplan apply"
+        return 0
+    fi
+
+    log "writing $NETPLAN_FILE for $iface (MAC $mac) → $host_ip/$prefix"
+    printf '%s\n' "$yaml" > "$NETPLAN_FILE"
+    chmod 0600 "$NETPLAN_FILE"
+    chown root:root "$NETPLAN_FILE"
+    netplan apply
+}
+
+verify() {
+    local host_ip="$1"
+    local deadline=$((SECONDS + 10))
+    while (( SECONDS < deadline )); do
+        if ip -o -4 addr show | grep -q "inet $host_ip/"; then
+            log "OK: $host_ip is assigned"
+            return 0
+        fi
+        sleep 1
+    done
+    err "$host_ip did not appear on any interface within 10s"
+    err "check 'ip -4 addr' and 'journalctl -u NetworkManager -u systemd-networkd -n 50'"
+    return 1
+}
+
+main() {
+    require_root
+
+    if [[ -z "$IFACE" ]]; then
+        IFACE=$(detect_iface)
+        log "auto-detected interface: $IFACE"
+    elif [[ ! -e "/sys/class/net/$IFACE" ]]; then
+        err "interface '$IFACE' not found"
+        exit 1
+    fi
+
+    local mac
+    mac=$(get_mac "$IFACE")
+    if [[ -z "$mac" || "$mac" == "00:00:00:00:00:00" ]]; then
+        err "interface $IFACE has no MAC address; is it up and cabled?"
+        exit 1
+    fi
+
+    local stack
+    stack=$(detect_stack)
+    case "$stack" in
+        nm)      apply_nm      "$IFACE" "$mac" "$HOST_IP" "$PREFIX" ;;
+        netplan) apply_netplan "$IFACE" "$mac" "$HOST_IP" "$PREFIX" ;;
+        *)
+            err "unsupported network stack; this script supports NetworkManager and netplan"
+            err "configure the interface manually — see README"
+            exit 1
+            ;;
+    esac
+
+    if [[ $DRY_RUN -eq 0 ]]; then
+        verify "$HOST_IP"
+    fi
+}
+
+main "$@"


### PR DESCRIPTION
## Summary

- Adds `tools/setup-arm-link.sh`, a one-shot script that configures a persistent static IP on the host's NIC for the dedicated xArm Ethernet link. Supports NetworkManager (Ubuntu Desktop, Raspberry Pi OS Bookworm+, Fedora/RHEL, Debian Desktop) and netplan (Ubuntu Server); binds the profile to the NIC's MAC so it survives interface-name changes. Auto-detects the interface when possible.
- Replaces the README's non-persistent `sudo ip addr add` Raspberry Pi snippet with a broader "Connecting using Linux" section that points at the script via `curl | sudo bash`. Also promotes the "Connecting using macOS/Linux" headings from `h4` to `h3` (they were incorrectly nested under "Trajectory Generator").
- Adds a startup warning in the Viam module: on Linux, if no local interface has an address on the configured arm host's `/24`, the module logs a one-time hint with the exact `curl | sudo bash` fix command and a README link. Pure no-op on any error path — never affects the connection flow.

## Motivation

Linux hosts that reach the arm over a dedicated Ethernet link need a static IP on the arm's subnet that survives reboots. The existing README used `sudo ip addr add`, which is ephemeral. Users were hitting "can't connect to the arm after reboot" and falling back to ad-hoc `nmcli` commands.

## Test plan

- [ ] Run `tools/setup-arm-link.sh --dry-run` on a Linux host with NetworkManager; verify the nmcli command it plans matches expectations.
- [ ] Run the script without `--dry-run`; verify a persistent profile (`xarm-link`) is created, the IP appears on the NIC, and survives a reboot.
- [ ] Test on Ubuntu Server (netplan path): verify `/etc/netplan/99-xarm-link.yaml` is written with mode 0600 and `netplan apply` picks it up.
- [ ] Start the module on a Linux host with no interface in `192.168.1.0/24`; verify the warning fires once with the correct script URL.
- [ ] Start the module on a correctly configured Linux host; verify no warning is logged.
- [ ] Start the module on macOS; verify no warning is logged regardless of network state.
- [ ] Configure the module with a hostname instead of an IP; verify no false-positive warning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)