### PR TITLE
fix speed check on xarm gripper set

### DIFF
--- a/arm/gripper.go
+++ b/arm/gripper.go
@@ -302,7 +302,7 @@ func (g *myGripper) goToPosition(ctx context.Context, goal int) (int, error) {
 	start := time.Now()
 
 	for {
-		time.Sleep(15 * time.Millisecond)
+		time.Sleep(30 * time.Millisecond)
 
 		pos, err := g.getPosition(ctx)
 		if err != nil {

--- a/arm/gripper.go
+++ b/arm/gripper.go
@@ -313,7 +313,9 @@ func (g *myGripper) goToPosition(ctx context.Context, goal int) (int, error) {
 			return pos, nil
 		}
 
-		if old >= 0 && math.Abs(float64(pos-old)) <= 2 {
+		// if the gripper has stopped moving, return
+		// might be grabbing something
+		if old >= 0 && math.Abs(float64(pos-old)) <= 1 {
 			return pos, nil
 		}
 


### PR DESCRIPTION
the "speed check" that returns if subsequent iterations of the position polling loop is too low was causing the gripper "set" docommand to return before the gripper had landed at the desired position, most of the time it returned immediately instead of blocking until the gripper was actually at the desired position