### PR TITLE
Add G2 gripper with force setting support and different geometries

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,23 @@ resp, err := xArmComponent.DoCommand(context.Background(), map[string]interface{
 // resp["gripper_speed"] contains the speed
 ```
 
+To set the gripper force (G2 only, range 1-100):
+
+```go
+xArmComponent.DoCommand(context.Background(), map[string]interface{}{
+    "set_gripper_force": 50,
+})
+```
+
+To get the current gripper force (G2 only):
+
+```go
+resp, err := xArmComponent.DoCommand(context.Background(), map[string]interface{}{
+    "get_gripper_force": true,
+})
+// resp["gripper_force"] contains the force
+```
+
 ### Manual Mode (Teaching Mode)
 
 You can put the arm into manual mode, which allows you to physically move the arm by hand. This is useful for teaching positions or manually positioning the arm for maintenance/storage.
@@ -295,6 +312,8 @@ The proxy port defaults to `18333`. If that port is unavailable on the host, set
 | `arm`            | string | **Required** | The name of the arm component this gripper is attached to.         |
 | `gripper_speed`  | int    | Optional     | Default gripper speed (1-5000). Applied on startup. If omitted, the gripper uses its firmware default. |
 
+Firmware default note: legacy G1 firmware default speed is `1500 r/min`. To avoid firmware/version differences, prefer setting `gripper_speed` explicitly.
+
 ### DoCommand
 
 ```go
@@ -309,6 +328,40 @@ resp, err := gripperComponent.DoCommand(context.Background(), map[string]interfa
 // Set/get gripper speed (proxied to arm DoCommand)
 resp, err := gripperComponent.DoCommand(context.Background(), map[string]interface{}{"set_gripper_speed": 2000})
 resp, err := gripperComponent.DoCommand(context.Background(), map[string]interface{}{"get_gripper_speed": true})
+```
+
+## gripper g2
+
+```jsonc
+{
+   "arm": "arm",            // required: name of the arm component
+   "gripper_speed": 2000,   // optional: default speed (1-5000)
+   "gripper_force": 50      // optional: default force (1-100)
+}
+```
+
+| Name             | Type   | Inclusion    | Description                                                        |
+|------------------|--------|--------------|--------------------------------------------------------------------|
+| `arm`            | string | **Required** | The name of the arm component this gripper is attached to.         |
+| `gripper_speed`  | int    | Optional     | Default gripper speed (1-5000). Applied on startup.                |
+| `gripper_force`  | int    | Optional     | Default gripper force (1-100). Applied on startup.                 |
+
+Firmware default note: G2 firmware default speed is `2000 r/min`. Prefer setting `gripper_speed` and `gripper_force` explicitly.
+
+### DoCommand
+
+```go
+// Get/move position (same as G1)
+resp, err := gripperComponent.DoCommand(context.Background(), map[string]interface{}{"get": true})
+resp, err := gripperComponent.DoCommand(context.Background(), map[string]interface{}{"set": 500.0})
+
+// Set/get speed
+resp, err := gripperComponent.DoCommand(context.Background(), map[string]interface{}{"set_gripper_speed": 2000})
+resp, err := gripperComponent.DoCommand(context.Background(), map[string]interface{}{"get_gripper_speed": true})
+
+// Set/get force
+resp, err := gripperComponent.DoCommand(context.Background(), map[string]interface{}{"set_gripper_force": 50})
+resp, err := gripperComponent.DoCommand(context.Background(), map[string]interface{}{"get_gripper_force": true})
 ```
 
 ## gripper lite

--- a/arm/comm.go
+++ b/arm/comm.go
@@ -1008,11 +1008,42 @@ func (x *xArm) getGripperSpeed(ctx context.Context) (uint16, error) {
 
 	x.logger.Debugf("getGripperSpeed: %v %v", res, res.params)
 
-	if len(res.params) != 7 {
-		return 0, fmt.Errorf("unexpected length for getGripperSpeed response: %d %v", len(res.params), res.params)
+	return parseGripperUint16Response(res.params, "getGripperSpeed")
+}
+
+func (x *xArm) setGripperForce(ctx context.Context, force uint16) error {
+	c := x.gripperPreamble(true)
+	c.params = append(c.params, 0x05, 0x00)
+	c.params = append(c.params, 0x00, 0x01)
+	c.params = append(c.params, 0x02)
+	tmpBytes := make([]byte, 2)
+	binary.BigEndian.PutUint16(tmpBytes, force)
+	x.logger.Debugf("setGripperForce bytes: %v", tmpBytes)
+	c.params = append(c.params, tmpBytes...)
+	_, err := x.send(ctx, c, true)
+	return err
+}
+
+func (x *xArm) getGripperForce(ctx context.Context) (uint16, error) {
+	c := x.gripperPreamble(false)
+	c.params = append(c.params, 0x05, 0x00)
+	c.params = append(c.params, 0x00, 0x01)
+	res, err := x.send(ctx, c, true)
+	if err != nil {
+		return 0, err
 	}
 
-	return binary.BigEndian.Uint16(res.params[5:]), nil
+	x.logger.Debugf("getGripperForce: %v %v", res, res.params)
+
+	return parseGripperUint16Response(res.params, "getGripperForce")
+}
+
+func parseGripperUint16Response(params []byte, command string) (uint16, error) {
+	if len(params) != 7 {
+		return 0, fmt.Errorf("unexpected length for %s response: %d %v", command, len(params), params)
+	}
+
+	return binary.BigEndian.Uint16(params[5:]), nil
 }
 
 func (x *xArm) getGripperPosition(ctx context.Context) (int32, error) {

--- a/arm/comm_gripper_test.go
+++ b/arm/comm_gripper_test.go
@@ -1,0 +1,22 @@
+package arm
+
+import (
+	"testing"
+
+	"go.viam.com/test"
+)
+
+func TestParseGripperUint16Response(t *testing.T) {
+	t.Run("valid response", func(t *testing.T) {
+		// Last two bytes are the register value.
+		v, err := parseGripperUint16Response([]byte{0x00, 0x09, 0x08, 0x03, 0x02, 0x07, 0xD0}, "getGripperSpeed")
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, v, test.ShouldEqual, 2000)
+	})
+
+	t.Run("invalid response length", func(t *testing.T) {
+		_, err := parseGripperUint16Response([]byte{0x00, 0x09}, "getGripperForce")
+		test.That(t, err, test.ShouldNotBeNil)
+		test.That(t, err.Error(), test.ShouldContainSubstring, "unexpected length for getGripperForce response")
+	})
+}

--- a/arm/gripper.go
+++ b/arm/gripper.go
@@ -22,6 +22,8 @@ import (
 const (
 	// ModelNameGripper is the gripper commonly attached to xArm6/xArm7.
 	ModelNameGripper = "gripper"
+	// ModelNameGripperG2 is the second generation ufactory gripper.
+	ModelNameGripperG2 = "gripper_g2"
 	// ModelNameGripperLite is the gripper commonly attached to the lite6.
 	ModelNameGripperLite = "gripper_lite"
 )
@@ -29,6 +31,8 @@ const (
 var (
 	// GripperModel model for the ufactory gripper.
 	GripperModel = family.WithModel(ModelNameGripper)
+	// GripperModelG2 model for the ufactory gripper g2.
+	GripperModelG2 = family.WithModel(ModelNameGripperG2)
 	// GripperModelLite model for the ufactory gripper-lite.
 	GripperModelLite = family.WithModel(ModelNameGripperLite)
 )
@@ -41,6 +45,7 @@ type GripperConfig struct {
 	Arm            string
 	VacuumLengthMM float64 `json:"vacuum_length_mm"`
 	GripperSpeed   int     `json:"gripper_speed,omitempty"`
+	GripperForce   int     `json:"gripper_force,omitempty"`
 }
 
 // Validate validates the config.
@@ -51,6 +56,9 @@ func (cfg *GripperConfig) Validate(path string) ([]string, []string, error) {
 	if cfg.GripperSpeed != 0 && (cfg.GripperSpeed < 1 || cfg.GripperSpeed > 5000) {
 		return nil, nil, fmt.Errorf("gripper_speed must be between 1 and 5000, got %d", cfg.GripperSpeed)
 	}
+	if cfg.GripperForce != 0 && (cfg.GripperForce < 1 || cfg.GripperForce > 100) {
+		return nil, nil, fmt.Errorf("gripper_force must be between 1 and 100, got %d", cfg.GripperForce)
+	}
 	return []string{cfg.Arm}, nil, nil
 }
 
@@ -60,6 +68,12 @@ func init() {
 		GripperModel,
 		resource.Registration[gripper.Gripper, *GripperConfig]{
 			Constructor: newGripper,
+		})
+	resource.RegisterComponent(
+		gripper.API,
+		GripperModelG2,
+		resource.Registration[gripper.Gripper, *GripperConfig]{
+			Constructor: newGripperG2,
 		})
 	resource.RegisterComponent(
 		gripper.API,
@@ -215,6 +229,8 @@ type myGripper struct {
 	mf   referenceframe.Model
 
 	arm arm.Arm
+	// supportsForce indicates whether this gripper supports force control.
+	supportsForce bool
 
 	goToPositionLock sync.Mutex
 	isMoving         atomic.Bool
@@ -229,25 +245,61 @@ func newGripper(ctx context.Context, deps resource.Dependencies, config resource
 	}
 
 	g := &myGripper{
-		name:   config.ResourceName(),
-		mf:     referenceframe.NewSimpleModel("xarm-gripper"),
-		logger: logger,
+		name:          config.ResourceName(),
+		mf:            referenceframe.NewSimpleModel("xarm-gripper"),
+		supportsForce: false,
+		logger:        logger,
 	}
 
-	g.arm, err = arm.FromProvider(deps, newConf.Arm)
+	if err := g.init(ctx, deps, newConf); err != nil {
+		return nil, err
+	}
+	return g, nil
+}
+
+func newGripperG2(ctx context.Context, deps resource.Dependencies, config resource.Config, logger logging.Logger) (gripper.Gripper, error) {
+	newConf, err := resource.NativeConfig[*GripperConfig](config)
 	if err != nil {
 		return nil, err
+	}
+
+	g := &myGripper{
+		name:          config.ResourceName(),
+		mf:            referenceframe.NewSimpleModel("xarm-gripper-g2"),
+		supportsForce: true,
+		logger:        logger,
+	}
+
+	if err := g.init(ctx, deps, newConf); err != nil {
+		return nil, err
+	}
+	return g, nil
+}
+
+func (g *myGripper) init(ctx context.Context, deps resource.Dependencies, newConf *GripperConfig) error {
+	var err error
+	g.arm, err = arm.FromProvider(deps, newConf.Arm)
+	if err != nil {
+		return err
 	}
 
 	if newConf.GripperSpeed != 0 {
 		if _, err := g.arm.DoCommand(ctx, map[string]any{
 			setGripperSpeedKey: float64(newConf.GripperSpeed),
 		}); err != nil {
-			return nil, fmt.Errorf("failed to set gripper speed: %w", err)
+			return fmt.Errorf("failed to set gripper speed: %w", err)
 		}
 	}
 
-	return g, nil
+	if g.supportsForce && newConf.GripperForce != 0 {
+		if _, err := g.arm.DoCommand(ctx, map[string]any{
+			setGripperForceKey: float64(newConf.GripperForce),
+		}); err != nil {
+			return fmt.Errorf("failed to set gripper force: %w", err)
+		}
+	}
+
+	return nil
 }
 
 func (g *myGripper) Grab(ctx context.Context, extra map[string]any) (bool, error) {
@@ -374,6 +426,18 @@ func (g *myGripper) DoCommand(ctx context.Context, cmd map[string]any) (map[stri
 	if _, ok := cmd[getGripperSpeedKey]; ok {
 		return g.arm.DoCommand(ctx, cmd)
 	}
+	if _, ok := cmd[setGripperForceKey]; ok {
+		if !g.supportsForce {
+			return nil, errors.ErrUnsupported
+		}
+		return g.arm.DoCommand(ctx, cmd)
+	}
+	if _, ok := cmd[getGripperForceKey]; ok {
+		if !g.supportsForce {
+			return nil, errors.ErrUnsupported
+		}
+		return g.arm.DoCommand(ctx, cmd)
+	}
 	return map[string]any{}, nil
 }
 
@@ -388,12 +452,20 @@ func (g *myGripper) Stop(context.Context, map[string]any) error {
 
 func (g *myGripper) Geometries(ctx context.Context, _ map[string]any) ([]spatialmath.Geometry, error) {
 	caseBoxSize := r3.Vector{X: 50, Y: 100, Z: 100}
+	clawSize := r3.Vector{X: 40, Y: 170, Z: 105} // size open (G1)
+	clawPose := r3.Vector{Z: 50 + (clawSize.Z / -2)}
+	if g.supportsForce {
+		// The G2 has a shorter nominal stroke (84mm) than the legacy gripper.
+		// Use a conservative geometry envelope until exact CAD dimensions are encoded.
+		caseBoxSize = r3.Vector{X: 58, Y: 90, Z: 112}
+		clawSize = r3.Vector{X: 45, Y: 120, Z: 112}
+		clawPose = r3.Vector{Z: 56 + (clawSize.Z / -2)}
+	}
+
 	caseBox, err := spatialmath.NewBox(spatialmath.NewPoseFromPoint(r3.Vector{X: 0, Y: 0, Z: caseBoxSize.Z / -2}), caseBoxSize, "case-gripper")
 	if err != nil {
 		return nil, err
 	}
-
-	clawSize := r3.Vector{X: 40, Y: 170, Z: 105} // size open
 
 	if false {
 		// until geometries aren't cacheed or model frame works differently can't do this
@@ -410,7 +482,7 @@ func (g *myGripper) Geometries(ctx context.Context, _ map[string]any) ([]spatial
 
 	g.logger.Debugf("clawSize: %v", clawSize)
 
-	claws, err := spatialmath.NewBox(spatialmath.NewPoseFromPoint(r3.Vector{Z: 50 + (clawSize.Z / -2)}), clawSize, "claws")
+	claws, err := spatialmath.NewBox(spatialmath.NewPoseFromPoint(clawPose), clawSize, "claws")
 	if err != nil {
 		return nil, err
 	}

--- a/arm/gripper_test.go
+++ b/arm/gripper_test.go
@@ -1,0 +1,48 @@
+package arm
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"go.viam.com/test"
+)
+
+func TestGripperConfigValidate(t *testing.T) {
+	t.Run("requires arm", func(t *testing.T) {
+		cfg := &GripperConfig{}
+		_, _, err := cfg.Validate("path")
+		test.That(t, err, test.ShouldNotBeNil)
+	})
+
+	t.Run("validates speed range", func(t *testing.T) {
+		cfg := &GripperConfig{Arm: "xarm", GripperSpeed: 5001}
+		_, _, err := cfg.Validate("path")
+		test.That(t, err, test.ShouldNotBeNil)
+		test.That(t, err.Error(), test.ShouldContainSubstring, "gripper_speed must be between 1 and 5000")
+	})
+
+	t.Run("validates force range", func(t *testing.T) {
+		cfg := &GripperConfig{Arm: "xarm", GripperForce: 101}
+		_, _, err := cfg.Validate("path")
+		test.That(t, err, test.ShouldNotBeNil)
+		test.That(t, err.Error(), test.ShouldContainSubstring, "gripper_force must be between 1 and 100")
+	})
+
+	t.Run("valid config", func(t *testing.T) {
+		cfg := &GripperConfig{Arm: "xarm", GripperSpeed: 2000, GripperForce: 50}
+		deps, _, err := cfg.Validate("path")
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, deps, test.ShouldResemble, []string{"xarm"})
+	})
+}
+
+func TestLegacyGripperRejectsForceDoCommand(t *testing.T) {
+	g := &myGripper{supportsForce: false}
+
+	_, err := g.DoCommand(context.Background(), map[string]any{setGripperForceKey: 50.0})
+	test.That(t, err, test.ShouldEqual, errors.ErrUnsupported)
+
+	_, err = g.DoCommand(context.Background(), map[string]any{getGripperForceKey: true})
+	test.That(t, err, test.ShouldEqual, errors.ErrUnsupported)
+}

--- a/arm/xarm.go
+++ b/arm/xarm.go
@@ -59,6 +59,9 @@ const (
 	setGripperSpeedKey       = "set_gripper_speed"
 	getGripperSpeedKey       = "get_gripper_speed"
 	gripperSpeedKey          = "gripper_speed"
+	setGripperForceKey       = "set_gripper_force"
+	getGripperForceKey       = "get_gripper_force"
+	gripperForceKey          = "gripper_force"
 	enterManualModeKey       = "enter_manual_mode"
 	exitManualModeKey        = "exit_manual_mode"
 
@@ -699,6 +702,36 @@ func (x *xArm) DoCommand(ctx context.Context, cmd map[string]any) (map[string]an
 			return nil, err
 		}
 		resp[gripperSpeedKey] = float64(speed)
+		validCommand = true
+	}
+
+	if val, ok := cmd[setGripperForceKey]; ok {
+		if err := x.setupGripper(ctx); err != nil {
+			return nil, err
+		}
+		force, err := utils.AssertType[float64](val)
+		if err != nil {
+			return nil, err
+		}
+		if force <= 0 || force > 100 {
+			return nil, fmt.Errorf("gripper force must be between 1 and 100, got %v", val)
+		}
+		if err := x.setGripperForce(ctx, uint16(force)); err != nil {
+			return nil, err
+		}
+		resp[gripperForceKey] = force
+		validCommand = true
+	}
+
+	if _, ok := cmd[getGripperForceKey]; ok {
+		if err := x.setupGripper(ctx); err != nil {
+			return nil, err
+		}
+		force, err := x.getGripperForce(ctx)
+		if err != nil {
+			return nil, err
+		}
+		resp[gripperForceKey] = float64(force)
 		validCommand = true
 	}
 

--- a/main.go
+++ b/main.go
@@ -16,6 +16,7 @@ func main() {
 		resource.APIModel{API: arm.API, Model: xarm.XArmLite6Model},
 		resource.APIModel{API: arm.API, Model: xarm.XArm850Model},
 		resource.APIModel{API: gripper.API, Model: xarm.GripperModel},
+		resource.APIModel{API: gripper.API, Model: xarm.GripperModelG2},
 		resource.APIModel{API: gripper.API, Model: xarm.GripperModelLite},
 		resource.APIModel{API: gripper.API, Model: xarm.VacuumGripperModel},
 		resource.APIModel{API: gripper.API, Model: xarm.VacuumGripperModelLite},

--- a/meta.json
+++ b/meta.json
@@ -37,6 +37,12 @@
     },
     {
       "api": "rdk:component:gripper",
+      "model": "viam:ufactory:gripper_g2",
+      "markdown_link": "README.md#gripper-g2",
+      "short_description": "gripper component driver for the ufactory gripper g2"
+    },
+    {
+      "api": "rdk:component:gripper",
       "model": "viam:ufactory:vacuum_gripper",
       "markdown_link": "README.md#vacuum-gripper",
       "short_description": "vacuum gripper component driver for the ufactory vacuum gripper"


### PR DESCRIPTION
ufactory started shipping a new gripper “G2” which has a few changes. When buying a new gripper from ufactory you can no longer purchase the “G1” version. We likely need to produce a separate gripper model due to the number of differences:

1. The default speed of closing gripper for G1 is 1500, G2 is 2000.
2. A 100ms sleep is needed between closing the gripper and calling IsHoldingSomething. Whatever is causing the need for delay on the client side should be internally adjusted/fixed in the ufactory module.
3. The G2 supports gripper force configuration which should be an attribute.
4. G2 has different geometry than G1:
	A. The G2 has a shorter nominal stroke (84mm) than the G1 gripper.
B. The G2 gripper is larger when fully open. G2 is r3.Vector{X: 45, Y: 120, Z: 112} vs G1  is r3.Vector{X: 40, Y: 170, Z: 105}.
C. The base plate of the gripper is thinner on G2 than G1 but it's unclear if that actually affects the geometry from a frame system POV.