### PR TITLE
add arm model and type auto detection

### DIFF
--- a/arm/comm.go
+++ b/arm/comm.go
@@ -562,13 +562,9 @@ func (x *xArm) createTrajGenSteps(
 ) ([][]referenceframe.Input, error) {
 	nWaypoints := len(positions) + 1
 	waypoints := make([]float64, 0, nWaypoints*x.dof)
-	for _, inp := range curPos {
-		waypoints = append(waypoints, inp)
-	}
+	waypoints = append(waypoints, curPos...)
 	for _, wp := range positions {
-		for _, inp := range wp {
-			waypoints = append(waypoints, inp)
-		}
+		waypoints = append(waypoints, wp...)
 	}
 
 	x.confLock.Lock()

--- a/arm/comm.go
+++ b/arm/comm.go
@@ -562,9 +562,13 @@ func (x *xArm) createTrajGenSteps(
 ) ([][]referenceframe.Input, error) {
 	nWaypoints := len(positions) + 1
 	waypoints := make([]float64, 0, nWaypoints*x.dof)
-	waypoints = append(waypoints, curPos...)
+	for _, inp := range curPos {
+		waypoints = append(waypoints, inp)
+	}
 	for _, wp := range positions {
-		waypoints = append(waypoints, wp...)
+		for _, inp := range wp {
+			waypoints = append(waypoints, inp)
+		}
 	}
 
 	x.confLock.Lock()

--- a/arm/detection.go
+++ b/arm/detection.go
@@ -78,7 +78,7 @@ type detectedGripper struct {
 // unknownGripper returns a detectedGripper whose Kind is gripperKindUnknown. Use
 // this instead of detectedGripper{} so the default carries the explicit label.
 func unknownGripper() detectedGripper {
-	return unknownGripper()
+	return detectedGripper{Kind: gripperKindUnknown}
 }
 
 func decodeHardwareModel(deviceType, axis byte) hardwareModel {
@@ -156,23 +156,26 @@ type versionInfo struct {
 // [^,]+ instead of a greedy .* — RE2 doesn't backtrack the same way.
 var versionBannerRE = regexp.MustCompile(`(\d+),(\d+),([^,]+),([^,]+),.*?[vV]?(\d+)\.(\d+)\.(\d+)`)
 
-func parseVersionBanner(banner string, logger logging.Logger) (versionInfo, bool) {
+func parseVersionBanner(banner string, logger logging.Logger) (versionInfo, error) {
 	m := versionBannerRE.FindStringSubmatch(banner)
 	if m == nil {
-		return versionInfo{}, false
+		return versionInfo{}, fmt.Errorf("could not parse version banner: %q", banner)
 	}
 	v := versionInfo{
 		armTypeStr:      m[3],
 		controlTypeStr:  m[4],
 		firmwareVersion: fmt.Sprintf("%s.%s.%s", m[5], m[6], m[7]),
 	}
-	// axis and deviceType come from regex group \d+ — Atoi can only fail on overflow,
-	// which is unreachable for these single-digit banner fields.
-	v.axis, _ = strconv.Atoi(m[1])
-	v.deviceType, _ = strconv.Atoi(m[2])
+	var err error
+	if v.axis, err = strconv.Atoi(m[1]); err != nil {
+		return versionInfo{}, fmt.Errorf("invalid axis %q in banner %q: %w", m[1], banner, err)
+	}
+	if v.deviceType, err = strconv.Atoi(m[2]); err != nil {
+		return versionInfo{}, fmt.Errorf("invalid device_type %q in banner %q: %w", m[2], banner, err)
+	}
 	v.armTypeCode = parseSubmodelCode(v.armTypeStr, "arm", logger)
 	v.controlTypeCode = parseSubmodelCode(v.controlTypeStr, "control", logger)
-	return v, true
+	return v, nil
 }
 
 // parseSubmodelCode extracts the 4-digit numeric code from SN positions [2:6]. A
@@ -200,11 +203,7 @@ func (x *xArm) detectVersion(ctx context.Context) (versionInfo, error) {
 		return versionInfo{}, fmt.Errorf("version response too short: %d (%v)", len(resp.params), resp.params)
 	}
 	banner := strings.TrimRight(string(resp.params[1:]), "\x00 ")
-	v, ok := parseVersionBanner(banner, x.logger)
-	if !ok {
-		return versionInfo{}, fmt.Errorf("could not parse version banner: %q", banner)
-	}
-	return v, nil
+	return parseVersionBanner(banner, x.logger)
 }
 
 // Modbus register start addresses used by gripper probes.
@@ -293,7 +292,7 @@ func probeGripper(ctx context.Context, a arm.Arm, kind gripperKind, logger loggi
 		logger.Warnf("%s gripper detection skipped: %v", kind, err)
 		return unknownGripper()
 	}
-	d := unknownGripper()
+	var d detectedGripper
 	switch kind {
 	case gripperKindStandard:
 		d, err = x.detectStandardGripper(ctx)

--- a/arm/detection.go
+++ b/arm/detection.go
@@ -10,6 +10,7 @@ import (
 
 	"go.viam.com/rdk/components/arm"
 	"go.viam.com/rdk/logging"
+	"go.viam.com/rdk/utils"
 )
 
 // hardwareModel identifies an xArm hardware family.
@@ -281,15 +282,12 @@ func (x *xArm) detectBioGripper(ctx context.Context) (detectedGripper, error) {
 }
 
 func probeGripper(ctx context.Context, a arm.Arm, kind gripperKind, logger logging.Logger) detectedGripper {
-	x, ok := a.(*xArm)
-	if !ok {
-		logger.Warnf("%s gripper detection skipped: arm dependency is not a *xArm (got %T)", kind, a)
+	x, err := utils.AssertType[*xArm](a)
+	if err != nil {
+		logger.Warnf("%s gripper detection skipped: %v", kind, err)
 		return detectedGripper{Kind: gripperKindUnknown}
 	}
-	var (
-		d   detectedGripper
-		err error
-	)
+	var d detectedGripper
 	switch kind {
 	case gripperKindStandard:
 		d, err = x.detectStandardGripper(ctx)

--- a/arm/detection.go
+++ b/arm/detection.go
@@ -153,7 +153,7 @@ type versionInfo struct {
 	firmwareVersion string
 }
 
-// [^,]+ instead of a greedy .* — RE2 doesn't backtrack the same way.
+// regex to parse xArm serial number format
 var versionBannerRE = regexp.MustCompile(`(\d+),(\d+),([^,]+),([^,]+),.*?[vV]?(\d+)\.(\d+)\.(\d+)`)
 
 func parseVersionBanner(banner string, logger logging.Logger) (versionInfo, error) {

--- a/arm/detection.go
+++ b/arm/detection.go
@@ -12,34 +12,34 @@ import (
 	"go.viam.com/rdk/logging"
 )
 
-// HardwareModel identifies an xArm hardware family.
-type HardwareModel string
+// hardwareModel identifies an xArm hardware family.
+type hardwareModel string
 
-// Known HardwareModel values.
+// Known hardwareModel values.
 const (
-	HardwareModelUnknown HardwareModel = "unknown"
-	HardwareModelXArm5   HardwareModel = "xArm5"
-	HardwareModelXArm6   HardwareModel = "xArm6"
-	HardwareModelXArm7   HardwareModel = "xArm7"
-	HardwareModelXArm7T  HardwareModel = "xArm7T"
-	HardwareModelLite6   HardwareModel = "lite6"
-	HardwareModelXArm850 HardwareModel = "xArm850"
+	hardwareModelUnknown hardwareModel = "unknown"
+	hardwareModelXArm5   hardwareModel = "xArm5"
+	hardwareModelXArm6   hardwareModel = "xArm6"
+	hardwareModelXArm7   hardwareModel = "xArm7"
+	hardwareModelXArm7T  hardwareModel = "xArm7T"
+	hardwareModelLite6   hardwareModel = "lite6"
+	hardwareModelXArm850 hardwareModel = "xArm850"
 )
 
-// GripperKind identifies a gripper hardware family.
-type GripperKind string
+// gripperKind identifies a gripper hardware family.
+type gripperKind string
 
-// Known GripperKind values.
+// Known gripperKind values.
 const (
-	GripperKindUnknown  GripperKind = "unknown"
-	GripperKindStandard GripperKind = "standard"
-	GripperKindBio      GripperKind = "bio"
-	GripperKindVacuum   GripperKind = "vacuum"
+	gripperKindUnknown  gripperKind = "unknown"
+	gripperKindStandard gripperKind = "standard"
+	gripperKindBio      gripperKind = "bio"
+	gripperKindVacuum   gripperKind = "vacuum"
 )
 
-// DetectedArm is the result of an arm-model probe.
-type DetectedArm struct {
-	Model           HardwareModel
+// detectedArm is the result of an arm-model probe.
+type detectedArm struct {
+	Model           hardwareModel
 	DeviceType      byte
 	Axis            byte
 	Submodel        string
@@ -48,66 +48,66 @@ type DetectedArm struct {
 	FirmwareVersion string
 }
 
-// DetectedGripper is the result of a gripper-hardware probe.
-type DetectedGripper struct {
-	Kind     GripperKind
+// detectedGripper is the result of a gripper-hardware probe.
+type detectedGripper struct {
+	Kind     gripperKind
 	Version  string
 	Submodel string
 }
 
-func decodeHardwareModel(deviceType, axis byte) HardwareModel {
+func decodeHardwareModel(deviceType, axis byte) hardwareModel {
 	switch deviceType {
 	case 3:
-		return HardwareModelXArm7
+		return hardwareModelXArm7
 	case 5:
-		return HardwareModelXArm5
+		return hardwareModelXArm5
 	case 6:
-		return HardwareModelXArm6
+		return hardwareModelXArm6
 	case 13:
-		return HardwareModelXArm7T
+		return hardwareModelXArm7T
 	case 9:
 		if axis == 6 {
-			return HardwareModelLite6
+			return hardwareModelLite6
 		}
 	case 12:
 		if axis == 6 {
-			return HardwareModelXArm850
+			return hardwareModelXArm850
 		}
 	}
-	return HardwareModelUnknown
+	return hardwareModelUnknown
 }
 
 // armModelFromSNPrefix is the authoritative model signal. GET_HD_TYPES is
 // harmonic-drive debug data (xarm-python-sdk doc/api/xarm_api.md:1757) and
 // the banner's leading "axis" digit is "1" on firmware 2.x; the SN prefix
 // from xarm.py:1841-1844 is what the SDKs actually trust.
-func armModelFromSNPrefix(armTypeStr string) (HardwareModel, byte) {
+func armModelFromSNPrefix(armTypeStr string) (hardwareModel, byte) {
 	if len(armTypeStr) < 2 {
-		return HardwareModelUnknown, 0
+		return hardwareModelUnknown, 0
 	}
 	switch armTypeStr[:2] {
 	case "XF":
-		return HardwareModelXArm5, 5
+		return hardwareModelXArm5, 5
 	case "XI":
-		return HardwareModelXArm6, 6
+		return hardwareModelXArm6, 6
 	case "XS":
-		return HardwareModelXArm7, 7
+		return hardwareModelXArm7, 7
 	case "CS":
-		return HardwareModelXArm7T, 7
+		return hardwareModelXArm7T, 7
 	case "LI":
-		return HardwareModelLite6, 6
+		return hardwareModelLite6, 6
 	case "FX":
-		return HardwareModelXArm850, 6
+		return hardwareModelXArm850, 6
 	}
-	return HardwareModelUnknown, 0
+	return hardwareModelUnknown, 0
 }
 
-func (x *xArm) detectArm(ctx context.Context) (DetectedArm, error) {
+func (x *xArm) detectArm(ctx context.Context) (detectedArm, error) {
 	v, err := x.detectVersion(ctx)
 	if err != nil {
-		return DetectedArm{Model: HardwareModelUnknown}, err
+		return detectedArm{Model: hardwareModelUnknown}, err
 	}
-	d := DetectedArm{
+	d := detectedArm{
 		DeviceType:      byte(v.deviceType),
 		Submodel:        v.armTypeStr,
 		ArmTypeCode:     v.armTypeCode,
@@ -177,27 +177,27 @@ func (x *xArm) detectVersion(ctx context.Context) (versionInfo, error) {
 	return v, nil
 }
 
-func (x *xArm) detectStandardGripper(ctx context.Context) (DetectedGripper, error) {
+func (x *xArm) detectStandardGripper(ctx context.Context) (detectedGripper, error) {
 	const numRegs = 3
 	c := x.gripperPreamble(false)
 	c.params = append(c.params, 0x08, 0x01)
 	c.params = append(c.params, 0x00, numRegs)
 	res, err := x.gripperSend(ctx, c)
 	if err != nil {
-		return DetectedGripper{Kind: GripperKindUnknown}, err
+		return detectedGripper{Kind: gripperKindUnknown}, err
 	}
 	const headerLen = 5
 	wantLen := headerLen + 2*numRegs
 	if len(res.params) < wantLen {
-		return DetectedGripper{Kind: GripperKindUnknown},
+		return detectedGripper{Kind: gripperKindUnknown},
 			fmt.Errorf("standard gripper version response too short: got %d, want %d (%v)", len(res.params), wantLen, res.params)
 	}
 	data := res.params[headerLen : headerLen+2*numRegs]
 	major := binary.BigEndian.Uint16(data[0:2])
 	minor := binary.BigEndian.Uint16(data[2:4])
 	patch := binary.BigEndian.Uint16(data[4:6])
-	return DetectedGripper{
-		Kind:     GripperKindStandard,
+	return detectedGripper{
+		Kind:     gripperKindStandard,
 		Version:  fmt.Sprintf("%d.%d.%d", major, minor, patch),
 		Submodel: standardGripperSubmodel(major, minor, patch),
 	}, nil
@@ -220,59 +220,59 @@ func standardGripperSubmodel(major, minor, patch uint16) string {
 
 // detectBioGripper: byteCount==2 means v1 (single-register response), 2*numRegs
 // means v2 (full SN). Matches xarm_bio.cc:_get_bio_gripper_sn.
-func (x *xArm) detectBioGripper(ctx context.Context) (DetectedGripper, error) {
+func (x *xArm) detectBioGripper(ctx context.Context) (detectedGripper, error) {
 	const numRegs = 16
 	c := x.gripperPreamble(false)
 	c.params = append(c.params, 0x0B, 0x10)
 	c.params = append(c.params, 0x00, numRegs)
 	res, err := x.gripperSend(ctx, c)
 	if err != nil {
-		return DetectedGripper{Kind: GripperKindUnknown}, err
+		return detectedGripper{Kind: gripperKindUnknown}, err
 	}
 	const headerLen = 5
 	if len(res.params) < headerLen {
-		return DetectedGripper{Kind: GripperKindUnknown},
+		return detectedGripper{Kind: gripperKindUnknown},
 			fmt.Errorf("bio gripper response too short: %d (%v)", len(res.params), res.params)
 	}
 	byteCount := res.params[headerLen-1]
 	switch byteCount {
 	case 2:
-		return DetectedGripper{Kind: GripperKindBio, Version: "1"}, nil
+		return detectedGripper{Kind: gripperKindBio, Version: "1"}, nil
 	case 2 * numRegs:
 		if len(res.params) < headerLen+int(byteCount) {
-			return DetectedGripper{Kind: GripperKindUnknown},
+			return detectedGripper{Kind: gripperKindUnknown},
 				fmt.Errorf("bio gripper response truncated: got %d, want %d", len(res.params), headerLen+int(byteCount))
 		}
 		sn := strings.TrimRight(string(res.params[headerLen:headerLen+int(byteCount)]), "\x00 ")
-		return DetectedGripper{Kind: GripperKindBio, Version: "2 sn=" + sn}, nil
+		return detectedGripper{Kind: gripperKindBio, Version: "2 sn=" + sn}, nil
 	default:
-		return DetectedGripper{Kind: GripperKindUnknown},
+		return detectedGripper{Kind: gripperKindUnknown},
 			fmt.Errorf("bio gripper unexpected byte count: %d (%v)", byteCount, res.params)
 	}
 }
 
-func probeGripper(ctx context.Context, a arm.Arm, kind GripperKind, logger logging.Logger) DetectedGripper {
+func probeGripper(ctx context.Context, a arm.Arm, kind gripperKind, logger logging.Logger) detectedGripper {
 	x, ok := a.(*xArm)
 	if !ok {
 		logger.Warnf("%s gripper detection skipped: arm dependency is not a *xArm (got %T)", kind, a)
-		return DetectedGripper{Kind: GripperKindUnknown}
+		return detectedGripper{Kind: gripperKindUnknown}
 	}
 	var (
-		d   DetectedGripper
+		d   detectedGripper
 		err error
 	)
 	switch kind {
-	case GripperKindStandard:
+	case gripperKindStandard:
 		d, err = x.detectStandardGripper(ctx)
-	case GripperKindBio:
+	case gripperKindBio:
 		d, err = x.detectBioGripper(ctx)
-	case GripperKindVacuum:
+	case gripperKindVacuum:
 		d, err = x.detectVacuumGripper(ctx)
-	case GripperKindUnknown:
-		return DetectedGripper{Kind: GripperKindUnknown}
+	case gripperKindUnknown:
+		return detectedGripper{Kind: gripperKindUnknown}
 	default:
 		logger.Warnf("gripper detection skipped: unrecognized kind %q", kind)
-		return DetectedGripper{Kind: GripperKindUnknown}
+		return detectedGripper{Kind: gripperKindUnknown}
 	}
 	if err != nil {
 		logger.Warnf("%s gripper detection failed: %v", kind, err)
@@ -282,19 +282,19 @@ func probeGripper(ctx context.Context, a arm.Arm, kind GripperKind, logger loggi
 	return d
 }
 
-func (x *xArm) detectVacuumGripper(ctx context.Context) (DetectedGripper, error) {
+func (x *xArm) detectVacuumGripper(ctx context.Context) (detectedGripper, error) {
 	c := x.newCmd(regMap["VacuumState"])
 	c.params = append(c.params, 0x09, 0x0A, 0x18)
 	resp, err := x.send(ctx, c, true)
 	if err != nil {
-		return DetectedGripper{Kind: GripperKindUnknown}, err
+		return detectedGripper{Kind: gripperKindUnknown}, err
 	}
 	if len(resp.params) < 5 {
-		return DetectedGripper{Kind: GripperKindUnknown},
+		return detectedGripper{Kind: gripperKindUnknown},
 			fmt.Errorf("vacuum gripper response too short: %d (%v)", len(resp.params), resp.params)
 	}
-	return DetectedGripper{
-		Kind:     GripperKindVacuum,
+	return detectedGripper{
+		Kind:     gripperKindVacuum,
 		Submodel: vacuumGripperSubmodel(x.detectedArm),
 	}, nil
 }
@@ -302,11 +302,11 @@ func (x *xArm) detectVacuumGripper(ctx context.Context) (DetectedGripper, error)
 // vacuumGripperSubmodel infers hardware revision from the arm: xarm-python-sdk
 // gpio.py:117 uses TGPIO outputs 3/4 (v2) for 850 and for xArm6/7 with
 // submodel >= 1305; older xArms use TGPIO 0/1 (v1); Lite 6 has its own bus.
-func vacuumGripperSubmodel(arm DetectedArm) string {
+func vacuumGripperSubmodel(arm detectedArm) string {
 	switch {
-	case arm.Model == HardwareModelLite6:
+	case arm.Model == hardwareModelLite6:
 		return "lite"
-	case arm.Model == HardwareModelXArm850:
+	case arm.Model == hardwareModelXArm850:
 		return "v2"
 	case arm.ArmTypeCode >= 1305:
 		return "v2"

--- a/arm/detection.go
+++ b/arm/detection.go
@@ -38,7 +38,7 @@ const (
 	gripperKindVacuum   gripperKind = "vacuum"
 )
 
-// Submodel labels reported in detectedGripper.Submodel.
+// Submodel labels reported in detectedGripper.submodel.
 const (
 	submodelV1   = "v1"
 	submodelV2   = "v2"
@@ -59,26 +59,26 @@ const (
 
 // detectedArm is the result of an arm-model probe.
 type detectedArm struct {
-	Model           hardwareModel
-	DeviceType      byte
-	Axis            byte
-	Submodel        string
-	ArmTypeCode     int
-	ControlTypeCode int
-	FirmwareVersion string
+	model           hardwareModel
+	deviceType      byte
+	axis            byte
+	submodel        string
+	armTypeCode     int
+	controlTypeCode int
+	firmwareVersion string
 }
 
 // detectedGripper is the result of a gripper-hardware probe.
 type detectedGripper struct {
-	Kind     gripperKind
-	Version  string
-	Submodel string
+	kind     gripperKind
+	version  string
+	submodel string
 }
 
-// unknownGripper returns a detectedGripper whose Kind is gripperKindUnknown. Use
+// unknownGripper returns a detectedGripper whose kind is gripperKindUnknown. Use
 // this instead of detectedGripper{} so the default carries the explicit label.
 func unknownGripper() detectedGripper {
-	return detectedGripper{Kind: gripperKindUnknown}
+	return detectedGripper{kind: gripperKindUnknown}
 }
 
 func decodeHardwareModel(deviceType, axis byte) hardwareModel {
@@ -130,16 +130,16 @@ func armModelFromSNPrefix(armTypeStr string) (hardwareModel, byte) {
 func (x *xArm) detectArm(ctx context.Context) (detectedArm, error) {
 	v, err := x.detectVersion(ctx)
 	if err != nil {
-		return detectedArm{Model: hardwareModelUnknown}, err
+		return detectedArm{model: hardwareModelUnknown}, err
 	}
 	d := detectedArm{
-		DeviceType:      byte(v.deviceType),
-		Submodel:        v.armTypeStr,
-		ArmTypeCode:     v.armTypeCode,
-		ControlTypeCode: v.controlTypeCode,
-		FirmwareVersion: v.firmwareVersion,
+		deviceType:      byte(v.deviceType),
+		submodel:        v.armTypeStr,
+		armTypeCode:     v.armTypeCode,
+		controlTypeCode: v.controlTypeCode,
+		firmwareVersion: v.firmwareVersion,
 	}
-	d.Model, d.Axis = armModelFromSNPrefix(v.armTypeStr)
+	d.model, d.axis = armModelFromSNPrefix(v.armTypeStr)
 	return d, nil
 }
 
@@ -153,7 +153,7 @@ type versionInfo struct {
 	firmwareVersion string
 }
 
-// regex to parse xArm serial number format
+// regex to parse xArm serial number format.
 var versionBannerRE = regexp.MustCompile(`(\d+),(\d+),([^,]+),([^,]+),.*?[vV]?(\d+)\.(\d+)\.(\d+)`)
 
 func parseVersionBanner(banner string, logger logging.Logger) (versionInfo, error) {
@@ -232,9 +232,9 @@ func (x *xArm) detectStandardGripper(ctx context.Context) (detectedGripper, erro
 	minor := binary.BigEndian.Uint16(data[2:4])
 	patch := binary.BigEndian.Uint16(data[4:6])
 	return detectedGripper{
-		Kind:     gripperKindStandard,
-		Version:  fmt.Sprintf("%d.%d.%d", major, minor, patch),
-		Submodel: standardGripperSubmodel(major, minor, patch),
+		kind:     gripperKindStandard,
+		version:  fmt.Sprintf("%d.%d.%d", major, minor, patch),
+		submodel: standardGripperSubmodel(major, minor, patch),
 	}, nil
 }
 
@@ -272,14 +272,14 @@ func (x *xArm) detectBioGripper(ctx context.Context) (detectedGripper, error) {
 	byteCount := res.params[headerLen-1]
 	switch byteCount {
 	case 2:
-		return detectedGripper{Kind: gripperKindBio, Version: "1"}, nil
+		return detectedGripper{kind: gripperKindBio, version: "1"}, nil
 	case 2 * numRegs:
 		if len(res.params) < headerLen+int(byteCount) {
 			return unknownGripper(),
 				fmt.Errorf("bio gripper response truncated: got %d, want %d", len(res.params), headerLen+int(byteCount))
 		}
 		sn := strings.TrimRight(string(res.params[headerLen:headerLen+int(byteCount)]), "\x00 ")
-		return detectedGripper{Kind: gripperKindBio, Version: "2 sn=" + sn}, nil
+		return detectedGripper{kind: gripperKindBio, version: "2 sn=" + sn}, nil
 	default:
 		return unknownGripper(),
 			fmt.Errorf("bio gripper unexpected byte count: %d (%v)", byteCount, res.params)
@@ -310,7 +310,7 @@ func probeGripper(ctx context.Context, a arm.Arm, kind gripperKind, logger loggi
 		logger.Warnf("%s gripper detection failed: %v", kind, err)
 		return d
 	}
-	logger.Infof("%s gripper detected (submodel=%q version=%q)", d.Kind, d.Submodel, d.Version)
+	logger.Infof("%s gripper detected (submodel=%q version=%q)", d.kind, d.submodel, d.version)
 	return d
 }
 
@@ -326,8 +326,8 @@ func (x *xArm) detectVacuumGripper(ctx context.Context) (detectedGripper, error)
 			fmt.Errorf("vacuum gripper response too short: %d (%v)", len(resp.params), resp.params)
 	}
 	return detectedGripper{
-		Kind:     gripperKindVacuum,
-		Submodel: vacuumGripperSubmodel(x.detectedArm),
+		kind:     gripperKindVacuum,
+		submodel: vacuumGripperSubmodel(x.detectedArm),
 	}, nil
 }
 
@@ -336,11 +336,11 @@ func (x *xArm) detectVacuumGripper(ctx context.Context) (detectedGripper, error)
 // TGPIO 0/1 (v1); Lite 6 has its own bus.
 func vacuumGripperSubmodel(arm detectedArm) string {
 	switch {
-	case arm.Model == hardwareModelLite6:
+	case arm.model == hardwareModelLite6:
 		return submodelLite
-	case arm.Model == hardwareModelXArm850:
+	case arm.model == hardwareModelXArm850:
 		return submodelV2
-	case arm.ArmTypeCode >= 1305:
+	case arm.armTypeCode >= 1305:
 		return submodelV2
 	default:
 		return submodelV1

--- a/arm/detection.go
+++ b/arm/detection.go
@@ -12,20 +12,24 @@ import (
 	"go.viam.com/rdk/logging"
 )
 
-type ArmModel string
+// HardwareModel identifies an xArm hardware family.
+type HardwareModel string
 
+// Known HardwareModel values.
 const (
-	ArmModelUnknown ArmModel = "unknown"
-	ArmModelXArm5   ArmModel = "xArm5"
-	ArmModelXArm6   ArmModel = "xArm6"
-	ArmModelXArm7   ArmModel = "xArm7"
-	ArmModelXArm7T  ArmModel = "xArm7T"
-	ArmModelLite6   ArmModel = "lite6"
-	ArmModelXArm850 ArmModel = "xArm850"
+	HardwareModelUnknown HardwareModel = "unknown"
+	HardwareModelXArm5   HardwareModel = "xArm5"
+	HardwareModelXArm6   HardwareModel = "xArm6"
+	HardwareModelXArm7   HardwareModel = "xArm7"
+	HardwareModelXArm7T  HardwareModel = "xArm7T"
+	HardwareModelLite6   HardwareModel = "lite6"
+	HardwareModelXArm850 HardwareModel = "xArm850"
 )
 
+// GripperKind identifies a gripper hardware family.
 type GripperKind string
 
+// Known GripperKind values.
 const (
 	GripperKindUnknown  GripperKind = "unknown"
 	GripperKindStandard GripperKind = "standard"
@@ -33,8 +37,9 @@ const (
 	GripperKindVacuum   GripperKind = "vacuum"
 )
 
+// DetectedArm is the result of an arm-model probe.
 type DetectedArm struct {
-	Model           ArmModel
+	Model           HardwareModel
 	DeviceType      byte
 	Axis            byte
 	Submodel        string
@@ -43,63 +48,64 @@ type DetectedArm struct {
 	FirmwareVersion string
 }
 
+// DetectedGripper is the result of a gripper-hardware probe.
 type DetectedGripper struct {
 	Kind     GripperKind
 	Version  string
 	Submodel string
 }
 
-func decodeArmModel(deviceType, axis byte) ArmModel {
+func decodeHardwareModel(deviceType, axis byte) HardwareModel {
 	switch deviceType {
 	case 3:
-		return ArmModelXArm7
+		return HardwareModelXArm7
 	case 5:
-		return ArmModelXArm5
+		return HardwareModelXArm5
 	case 6:
-		return ArmModelXArm6
+		return HardwareModelXArm6
 	case 13:
-		return ArmModelXArm7T
+		return HardwareModelXArm7T
 	case 9:
 		if axis == 6 {
-			return ArmModelLite6
+			return HardwareModelLite6
 		}
 	case 12:
 		if axis == 6 {
-			return ArmModelXArm850
+			return HardwareModelXArm850
 		}
 	}
-	return ArmModelUnknown
+	return HardwareModelUnknown
 }
 
 // armModelFromSNPrefix is the authoritative model signal. GET_HD_TYPES is
 // harmonic-drive debug data (xarm-python-sdk doc/api/xarm_api.md:1757) and
 // the banner's leading "axis" digit is "1" on firmware 2.x; the SN prefix
 // from xarm.py:1841-1844 is what the SDKs actually trust.
-func armModelFromSNPrefix(armTypeStr string) (ArmModel, byte) {
+func armModelFromSNPrefix(armTypeStr string) (HardwareModel, byte) {
 	if len(armTypeStr) < 2 {
-		return ArmModelUnknown, 0
+		return HardwareModelUnknown, 0
 	}
 	switch armTypeStr[:2] {
 	case "XF":
-		return ArmModelXArm5, 5
+		return HardwareModelXArm5, 5
 	case "XI":
-		return ArmModelXArm6, 6
+		return HardwareModelXArm6, 6
 	case "XS":
-		return ArmModelXArm7, 7
+		return HardwareModelXArm7, 7
 	case "CS":
-		return ArmModelXArm7T, 7
+		return HardwareModelXArm7T, 7
 	case "LI":
-		return ArmModelLite6, 6
+		return HardwareModelLite6, 6
 	case "FX":
-		return ArmModelXArm850, 6
+		return HardwareModelXArm850, 6
 	}
-	return ArmModelUnknown, 0
+	return HardwareModelUnknown, 0
 }
 
 func (x *xArm) detectArm(ctx context.Context) (DetectedArm, error) {
 	v, err := x.detectVersion(ctx)
 	if err != nil {
-		return DetectedArm{Model: ArmModelUnknown}, err
+		return DetectedArm{Model: HardwareModelUnknown}, err
 	}
 	d := DetectedArm{
 		DeviceType:      byte(v.deviceType),
@@ -135,15 +141,23 @@ func parseVersionBanner(banner string) (versionInfo, bool) {
 		controlTypeStr:  m[4],
 		firmwareVersion: fmt.Sprintf("%s.%s.%s", m[5], m[6], m[7]),
 	}
-	v.axis, _ = strconv.Atoi(m[1])
-	v.deviceType, _ = strconv.Atoi(m[2])
+	v.axis = atoiOrZero(m[1])
+	v.deviceType = atoiOrZero(m[2])
 	if len(v.armTypeStr) >= 6 {
-		v.armTypeCode, _ = strconv.Atoi(v.armTypeStr[2:6])
+		v.armTypeCode = atoiOrZero(v.armTypeStr[2:6])
 	}
 	if len(v.controlTypeStr) >= 6 {
-		v.controlTypeCode, _ = strconv.Atoi(v.controlTypeStr[2:6])
+		v.controlTypeCode = atoiOrZero(v.controlTypeStr[2:6])
 	}
 	return v, true
+}
+
+func atoiOrZero(s string) int {
+	n, err := strconv.Atoi(s)
+	if err != nil {
+		return 0
+	}
+	return n
 }
 
 func (x *xArm) detectVersion(ctx context.Context) (versionInfo, error) {
@@ -153,7 +167,7 @@ func (x *xArm) detectVersion(ctx context.Context) (versionInfo, error) {
 		return versionInfo{}, err
 	}
 	if len(resp.params) < 2 {
-		return versionInfo{}, fmt.Errorf("Version response too short: %d (%v)", len(resp.params), resp.params)
+		return versionInfo{}, fmt.Errorf("version response too short: %d (%v)", len(resp.params), resp.params)
 	}
 	banner := strings.TrimRight(string(resp.params[1:]), "\x00 ")
 	v, ok := parseVersionBanner(banner)
@@ -254,8 +268,10 @@ func probeGripper(ctx context.Context, a arm.Arm, kind GripperKind, logger loggi
 		d, err = x.detectBioGripper(ctx)
 	case GripperKindVacuum:
 		d, err = x.detectVacuumGripper(ctx)
+	case GripperKindUnknown:
+		return DetectedGripper{Kind: GripperKindUnknown}
 	default:
-		logger.Warnf("gripper detection skipped: unknown kind %q", kind)
+		logger.Warnf("gripper detection skipped: unrecognized kind %q", kind)
 		return DetectedGripper{Kind: GripperKindUnknown}
 	}
 	if err != nil {
@@ -288,9 +304,9 @@ func (x *xArm) detectVacuumGripper(ctx context.Context) (DetectedGripper, error)
 // submodel >= 1305; older xArms use TGPIO 0/1 (v1); Lite 6 has its own bus.
 func vacuumGripperSubmodel(arm DetectedArm) string {
 	switch {
-	case arm.Model == ArmModelLite6:
+	case arm.Model == HardwareModelLite6:
 		return "lite"
-	case arm.Model == ArmModelXArm850:
+	case arm.Model == HardwareModelXArm850:
 		return "v2"
 	case arm.ArmTypeCode >= 1305:
 		return "v2"

--- a/arm/detection.go
+++ b/arm/detection.go
@@ -75,6 +75,12 @@ type detectedGripper struct {
 	Submodel string
 }
 
+// unknownGripper returns a detectedGripper whose Kind is gripperKindUnknown. Use
+// this instead of detectedGripper{} so the default carries the explicit label.
+func unknownGripper() detectedGripper {
+	return unknownGripper()
+}
+
 func decodeHardwareModel(deviceType, axis byte) hardwareModel {
 	switch deviceType {
 	case 3:
@@ -214,12 +220,12 @@ func (x *xArm) detectStandardGripper(ctx context.Context) (detectedGripper, erro
 	c.params = binary.BigEndian.AppendUint16(c.params, numRegs)
 	res, err := x.gripperSend(ctx, c)
 	if err != nil {
-		return detectedGripper{Kind: gripperKindUnknown}, err
+		return unknownGripper(), err
 	}
 	const headerLen = 5
 	wantLen := headerLen + 2*numRegs
 	if len(res.params) < wantLen {
-		return detectedGripper{Kind: gripperKindUnknown},
+		return unknownGripper(),
 			fmt.Errorf("standard gripper version response too short: got %d, want %d (%v)", len(res.params), wantLen, res.params)
 	}
 	data := res.params[headerLen : headerLen+2*numRegs]
@@ -257,11 +263,11 @@ func (x *xArm) detectBioGripper(ctx context.Context) (detectedGripper, error) {
 	c.params = binary.BigEndian.AppendUint16(c.params, numRegs)
 	res, err := x.gripperSend(ctx, c)
 	if err != nil {
-		return detectedGripper{Kind: gripperKindUnknown}, err
+		return unknownGripper(), err
 	}
 	const headerLen = 5
 	if len(res.params) < headerLen {
-		return detectedGripper{Kind: gripperKindUnknown},
+		return unknownGripper(),
 			fmt.Errorf("bio gripper response too short: %d (%v)", len(res.params), res.params)
 	}
 	byteCount := res.params[headerLen-1]
@@ -270,13 +276,13 @@ func (x *xArm) detectBioGripper(ctx context.Context) (detectedGripper, error) {
 		return detectedGripper{Kind: gripperKindBio, Version: "1"}, nil
 	case 2 * numRegs:
 		if len(res.params) < headerLen+int(byteCount) {
-			return detectedGripper{Kind: gripperKindUnknown},
+			return unknownGripper(),
 				fmt.Errorf("bio gripper response truncated: got %d, want %d", len(res.params), headerLen+int(byteCount))
 		}
 		sn := strings.TrimRight(string(res.params[headerLen:headerLen+int(byteCount)]), "\x00 ")
 		return detectedGripper{Kind: gripperKindBio, Version: "2 sn=" + sn}, nil
 	default:
-		return detectedGripper{Kind: gripperKindUnknown},
+		return unknownGripper(),
 			fmt.Errorf("bio gripper unexpected byte count: %d (%v)", byteCount, res.params)
 	}
 }
@@ -285,9 +291,9 @@ func probeGripper(ctx context.Context, a arm.Arm, kind gripperKind, logger loggi
 	x, err := utils.AssertType[*xArm](a)
 	if err != nil {
 		logger.Warnf("%s gripper detection skipped: %v", kind, err)
-		return detectedGripper{Kind: gripperKindUnknown}
+		return unknownGripper()
 	}
-	var d detectedGripper
+	d := unknownGripper()
 	switch kind {
 	case gripperKindStandard:
 		d, err = x.detectStandardGripper(ctx)
@@ -296,10 +302,10 @@ func probeGripper(ctx context.Context, a arm.Arm, kind gripperKind, logger loggi
 	case gripperKindVacuum:
 		d, err = x.detectVacuumGripper(ctx)
 	case gripperKindUnknown:
-		return detectedGripper{Kind: gripperKindUnknown}
+		return unknownGripper()
 	default:
 		logger.Warnf("gripper detection skipped: unrecognized kind %q", kind)
-		return detectedGripper{Kind: gripperKindUnknown}
+		return unknownGripper()
 	}
 	if err != nil {
 		logger.Warnf("%s gripper detection failed: %v", kind, err)
@@ -314,10 +320,10 @@ func (x *xArm) detectVacuumGripper(ctx context.Context) (detectedGripper, error)
 	c.params = append(c.params, 0x09, 0x0A, 0x18)
 	resp, err := x.send(ctx, c, true)
 	if err != nil {
-		return detectedGripper{Kind: gripperKindUnknown}, err
+		return unknownGripper(), err
 	}
 	if len(resp.params) < 5 {
-		return detectedGripper{Kind: gripperKindUnknown},
+		return unknownGripper(),
 			fmt.Errorf("vacuum gripper response too short: %d (%v)", len(resp.params), resp.params)
 	}
 	return detectedGripper{

--- a/arm/detection.go
+++ b/arm/detection.go
@@ -1,0 +1,300 @@
+package arm
+
+import (
+	"context"
+	"encoding/binary"
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"go.viam.com/rdk/components/arm"
+	"go.viam.com/rdk/logging"
+)
+
+type ArmModel string
+
+const (
+	ArmModelUnknown ArmModel = "unknown"
+	ArmModelXArm5   ArmModel = "xArm5"
+	ArmModelXArm6   ArmModel = "xArm6"
+	ArmModelXArm7   ArmModel = "xArm7"
+	ArmModelXArm7T  ArmModel = "xArm7T"
+	ArmModelLite6   ArmModel = "lite6"
+	ArmModelXArm850 ArmModel = "xArm850"
+)
+
+type GripperKind string
+
+const (
+	GripperKindUnknown  GripperKind = "unknown"
+	GripperKindStandard GripperKind = "standard"
+	GripperKindBio      GripperKind = "bio"
+	GripperKindVacuum   GripperKind = "vacuum"
+)
+
+type DetectedArm struct {
+	Model           ArmModel
+	DeviceType      byte
+	Axis            byte
+	Submodel        string
+	ArmTypeCode     int
+	ControlTypeCode int
+	FirmwareVersion string
+}
+
+type DetectedGripper struct {
+	Kind     GripperKind
+	Version  string
+	Submodel string
+}
+
+func decodeArmModel(deviceType, axis byte) ArmModel {
+	switch deviceType {
+	case 3:
+		return ArmModelXArm7
+	case 5:
+		return ArmModelXArm5
+	case 6:
+		return ArmModelXArm6
+	case 13:
+		return ArmModelXArm7T
+	case 9:
+		if axis == 6 {
+			return ArmModelLite6
+		}
+	case 12:
+		if axis == 6 {
+			return ArmModelXArm850
+		}
+	}
+	return ArmModelUnknown
+}
+
+// armModelFromSNPrefix is the authoritative model signal. GET_HD_TYPES is
+// harmonic-drive debug data (xarm-python-sdk doc/api/xarm_api.md:1757) and
+// the banner's leading "axis" digit is "1" on firmware 2.x; the SN prefix
+// from xarm.py:1841-1844 is what the SDKs actually trust.
+func armModelFromSNPrefix(armTypeStr string) (ArmModel, byte) {
+	if len(armTypeStr) < 2 {
+		return ArmModelUnknown, 0
+	}
+	switch armTypeStr[:2] {
+	case "XF":
+		return ArmModelXArm5, 5
+	case "XI":
+		return ArmModelXArm6, 6
+	case "XS":
+		return ArmModelXArm7, 7
+	case "CS":
+		return ArmModelXArm7T, 7
+	case "LI":
+		return ArmModelLite6, 6
+	case "FX":
+		return ArmModelXArm850, 6
+	}
+	return ArmModelUnknown, 0
+}
+
+func (x *xArm) detectArm(ctx context.Context) (DetectedArm, error) {
+	v, err := x.detectVersion(ctx)
+	if err != nil {
+		return DetectedArm{Model: ArmModelUnknown}, err
+	}
+	d := DetectedArm{
+		DeviceType:      byte(v.deviceType),
+		Submodel:        v.armTypeStr,
+		ArmTypeCode:     v.armTypeCode,
+		ControlTypeCode: v.controlTypeCode,
+		FirmwareVersion: v.firmwareVersion,
+	}
+	d.Model, d.Axis = armModelFromSNPrefix(v.armTypeStr)
+	return d, nil
+}
+
+type versionInfo struct {
+	axis            int
+	deviceType      int
+	armTypeStr      string
+	controlTypeStr  string
+	armTypeCode     int
+	controlTypeCode int
+	firmwareVersion string
+}
+
+// [^,]+ instead of the C++ SDK's greedy .* — RE2 doesn't backtrack the same way.
+var versionBannerRE = regexp.MustCompile(`(\d+),(\d+),([^,]+),([^,]+),.*?[vV]?(\d+)\.(\d+)\.(\d+)`)
+
+func parseVersionBanner(banner string) (versionInfo, bool) {
+	m := versionBannerRE.FindStringSubmatch(banner)
+	if m == nil {
+		return versionInfo{}, false
+	}
+	v := versionInfo{
+		armTypeStr:      m[3],
+		controlTypeStr:  m[4],
+		firmwareVersion: fmt.Sprintf("%s.%s.%s", m[5], m[6], m[7]),
+	}
+	v.axis, _ = strconv.Atoi(m[1])
+	v.deviceType, _ = strconv.Atoi(m[2])
+	if len(v.armTypeStr) >= 6 {
+		v.armTypeCode, _ = strconv.Atoi(v.armTypeStr[2:6])
+	}
+	if len(v.controlTypeStr) >= 6 {
+		v.controlTypeCode, _ = strconv.Atoi(v.controlTypeStr[2:6])
+	}
+	return v, true
+}
+
+func (x *xArm) detectVersion(ctx context.Context) (versionInfo, error) {
+	c := x.newCmd(regMap["Version"])
+	resp, err := x.send(ctx, c, true)
+	if err != nil {
+		return versionInfo{}, err
+	}
+	if len(resp.params) < 2 {
+		return versionInfo{}, fmt.Errorf("Version response too short: %d (%v)", len(resp.params), resp.params)
+	}
+	banner := strings.TrimRight(string(resp.params[1:]), "\x00 ")
+	v, ok := parseVersionBanner(banner)
+	if !ok {
+		return versionInfo{}, fmt.Errorf("could not parse version banner: %q", banner)
+	}
+	return v, nil
+}
+
+func (x *xArm) detectStandardGripper(ctx context.Context) (DetectedGripper, error) {
+	const numRegs = 3
+	c := x.gripperPreamble(false)
+	c.params = append(c.params, 0x08, 0x01)
+	c.params = append(c.params, 0x00, numRegs)
+	res, err := x.gripperSend(ctx, c)
+	if err != nil {
+		return DetectedGripper{Kind: GripperKindUnknown}, err
+	}
+	const headerLen = 5
+	wantLen := headerLen + 2*numRegs
+	if len(res.params) < wantLen {
+		return DetectedGripper{Kind: GripperKindUnknown},
+			fmt.Errorf("standard gripper version response too short: got %d, want %d (%v)", len(res.params), wantLen, res.params)
+	}
+	data := res.params[headerLen : headerLen+2*numRegs]
+	major := binary.BigEndian.Uint16(data[0:2])
+	minor := binary.BigEndian.Uint16(data[2:4])
+	patch := binary.BigEndian.Uint16(data[4:6])
+	return DetectedGripper{
+		Kind:     GripperKindStandard,
+		Version:  fmt.Sprintf("%d.%d.%d", major, minor, patch),
+		Submodel: standardGripperSubmodel(major, minor, patch),
+	}, nil
+}
+
+// standardGripperSubmodel splits at firmware >= 3.4.3, the gate the Python
+// SDK uses for status-reporting support (gripper.py:83-85).
+func standardGripperSubmodel(major, minor, patch uint16) string {
+	switch {
+	case major > 3:
+		return "v2"
+	case major == 3 && minor > 4:
+		return "v2"
+	case major == 3 && minor == 4 && patch >= 3:
+		return "v2"
+	default:
+		return "v1"
+	}
+}
+
+// detectBioGripper: byteCount==2 means v1 (single-register response), 2*numRegs
+// means v2 (full SN). Matches xarm_bio.cc:_get_bio_gripper_sn.
+func (x *xArm) detectBioGripper(ctx context.Context) (DetectedGripper, error) {
+	const numRegs = 16
+	c := x.gripperPreamble(false)
+	c.params = append(c.params, 0x0B, 0x10)
+	c.params = append(c.params, 0x00, numRegs)
+	res, err := x.gripperSend(ctx, c)
+	if err != nil {
+		return DetectedGripper{Kind: GripperKindUnknown}, err
+	}
+	const headerLen = 5
+	if len(res.params) < headerLen {
+		return DetectedGripper{Kind: GripperKindUnknown},
+			fmt.Errorf("bio gripper response too short: %d (%v)", len(res.params), res.params)
+	}
+	byteCount := res.params[headerLen-1]
+	switch byteCount {
+	case 2:
+		return DetectedGripper{Kind: GripperKindBio, Version: "1"}, nil
+	case 2 * numRegs:
+		if len(res.params) < headerLen+int(byteCount) {
+			return DetectedGripper{Kind: GripperKindUnknown},
+				fmt.Errorf("bio gripper response truncated: got %d, want %d", len(res.params), headerLen+int(byteCount))
+		}
+		sn := strings.TrimRight(string(res.params[headerLen:headerLen+int(byteCount)]), "\x00 ")
+		return DetectedGripper{Kind: GripperKindBio, Version: "2 sn=" + sn}, nil
+	default:
+		return DetectedGripper{Kind: GripperKindUnknown},
+			fmt.Errorf("bio gripper unexpected byte count: %d (%v)", byteCount, res.params)
+	}
+}
+
+func probeGripper(ctx context.Context, a arm.Arm, kind GripperKind, logger logging.Logger) DetectedGripper {
+	x, ok := a.(*xArm)
+	if !ok {
+		logger.Warnf("%s gripper detection skipped: arm dependency is not a *xArm (got %T)", kind, a)
+		return DetectedGripper{Kind: GripperKindUnknown}
+	}
+	var (
+		d   DetectedGripper
+		err error
+	)
+	switch kind {
+	case GripperKindStandard:
+		d, err = x.detectStandardGripper(ctx)
+	case GripperKindBio:
+		d, err = x.detectBioGripper(ctx)
+	case GripperKindVacuum:
+		d, err = x.detectVacuumGripper(ctx)
+	default:
+		logger.Warnf("gripper detection skipped: unknown kind %q", kind)
+		return DetectedGripper{Kind: GripperKindUnknown}
+	}
+	if err != nil {
+		logger.Warnf("%s gripper detection failed: %v", kind, err)
+		return d
+	}
+	logger.Infof("%s gripper detected (submodel=%q version=%q)", d.Kind, d.Submodel, d.Version)
+	return d
+}
+
+func (x *xArm) detectVacuumGripper(ctx context.Context) (DetectedGripper, error) {
+	c := x.newCmd(regMap["VacuumState"])
+	c.params = append(c.params, 0x09, 0x0A, 0x18)
+	resp, err := x.send(ctx, c, true)
+	if err != nil {
+		return DetectedGripper{Kind: GripperKindUnknown}, err
+	}
+	if len(resp.params) < 5 {
+		return DetectedGripper{Kind: GripperKindUnknown},
+			fmt.Errorf("vacuum gripper response too short: %d (%v)", len(resp.params), resp.params)
+	}
+	return DetectedGripper{
+		Kind:     GripperKindVacuum,
+		Submodel: vacuumGripperSubmodel(x.detectedArm),
+	}, nil
+}
+
+// vacuumGripperSubmodel infers hardware revision from the arm: xarm-python-sdk
+// gpio.py:117 uses TGPIO outputs 3/4 (v2) for 850 and for xArm6/7 with
+// submodel >= 1305; older xArms use TGPIO 0/1 (v1); Lite 6 has its own bus.
+func vacuumGripperSubmodel(arm DetectedArm) string {
+	switch {
+	case arm.Model == ArmModelLite6:
+		return "lite"
+	case arm.Model == ArmModelXArm850:
+		return "v2"
+	case arm.ArmTypeCode >= 1305:
+		return "v2"
+	default:
+		return "v1"
+	}
+}

--- a/arm/detection.go
+++ b/arm/detection.go
@@ -181,11 +181,17 @@ func (x *xArm) detectVersion(ctx context.Context) (versionInfo, error) {
 	return v, nil
 }
 
+// Modbus register start addresses used by gripper probes.
+const (
+	standardGripperVersionReg uint16 = 0x0801 // SOFT_VER, 3 consecutive regs: major.minor.patch
+	bioGripperSNReg           uint16 = 0x0B10 // BIO serial-number block, up to 16 regs
+)
+
 func (x *xArm) detectStandardGripper(ctx context.Context) (detectedGripper, error) {
 	const numRegs = 3
 	c := x.gripperPreamble(false)
-	c.params = append(c.params, 0x08, 0x01)
-	c.params = append(c.params, 0x00, numRegs)
+	c.params = binary.BigEndian.AppendUint16(c.params, standardGripperVersionReg)
+	c.params = binary.BigEndian.AppendUint16(c.params, numRegs)
 	res, err := x.gripperSend(ctx, c)
 	if err != nil {
 		return detectedGripper{Kind: gripperKindUnknown}, err
@@ -227,8 +233,8 @@ func standardGripperSubmodel(major, minor, patch uint16) string {
 func (x *xArm) detectBioGripper(ctx context.Context) (detectedGripper, error) {
 	const numRegs = 16
 	c := x.gripperPreamble(false)
-	c.params = append(c.params, 0x0B, 0x10)
-	c.params = append(c.params, 0x00, numRegs)
+	c.params = binary.BigEndian.AppendUint16(c.params, bioGripperSNReg)
+	c.params = binary.BigEndian.AppendUint16(c.params, numRegs)
 	res, err := x.gripperSend(ctx, c)
 	if err != nil {
 		return detectedGripper{Kind: gripperKindUnknown}, err

--- a/arm/detection.go
+++ b/arm/detection.go
@@ -78,9 +78,8 @@ func decodeHardwareModel(deviceType, axis byte) hardwareModel {
 }
 
 // armModelFromSNPrefix is the authoritative model signal. GET_HD_TYPES is
-// harmonic-drive debug data (xarm-python-sdk doc/api/xarm_api.md:1757) and
-// the banner's leading "axis" digit is "1" on firmware 2.x; the SN prefix
-// from xarm.py:1841-1844 is what the SDKs actually trust.
+// harmonic-drive debug data, and the banner's leading "axis" digit is "1" on
+// firmware 2.x; the two-letter SN prefix is what UFactory's SDKs actually trust.
 func armModelFromSNPrefix(armTypeStr string) (hardwareModel, byte) {
 	if len(armTypeStr) < 2 {
 		return hardwareModelUnknown, 0
@@ -128,10 +127,10 @@ type versionInfo struct {
 	firmwareVersion string
 }
 
-// [^,]+ instead of the C++ SDK's greedy .* — RE2 doesn't backtrack the same way.
+// [^,]+ instead of a greedy .* — RE2 doesn't backtrack the same way.
 var versionBannerRE = regexp.MustCompile(`(\d+),(\d+),([^,]+),([^,]+),.*?[vV]?(\d+)\.(\d+)\.(\d+)`)
 
-func parseVersionBanner(banner string) (versionInfo, bool) {
+func parseVersionBanner(banner string, logger logging.Logger) (versionInfo, bool) {
 	m := versionBannerRE.FindStringSubmatch(banner)
 	if m == nil {
 		return versionInfo{}, false
@@ -141,23 +140,28 @@ func parseVersionBanner(banner string) (versionInfo, bool) {
 		controlTypeStr:  m[4],
 		firmwareVersion: fmt.Sprintf("%s.%s.%s", m[5], m[6], m[7]),
 	}
-	v.axis = atoiOrZero(m[1])
-	v.deviceType = atoiOrZero(m[2])
-	if len(v.armTypeStr) >= 6 {
-		v.armTypeCode = atoiOrZero(v.armTypeStr[2:6])
-	}
-	if len(v.controlTypeStr) >= 6 {
-		v.controlTypeCode = atoiOrZero(v.controlTypeStr[2:6])
-	}
+	// axis and deviceType come from regex group \d+ — Atoi can only fail on overflow,
+	// which is unreachable for these single-digit banner fields.
+	v.axis, _ = strconv.Atoi(m[1])
+	v.deviceType, _ = strconv.Atoi(m[2])
+	v.armTypeCode = parseSubmodelCode(v.armTypeStr, "arm", logger)
+	v.controlTypeCode = parseSubmodelCode(v.controlTypeStr, "control", logger)
 	return v, true
 }
 
-func atoiOrZero(s string) int {
-	n, err := strconv.Atoi(s)
-	if err != nil {
+// parseSubmodelCode extracts the 4-digit numeric code from SN positions [2:6]. A
+// non-digit value means UFactory shipped a SN format we don't recognize — log and
+// fall back to 0 so detection can still proceed using the 2-char prefix.
+func parseSubmodelCode(s, kind string, logger logging.Logger) int {
+	if len(s) < 6 {
 		return 0
 	}
-	return n
+	code, err := strconv.Atoi(s[2:6])
+	if err != nil {
+		logger.Warnf("could not parse %s submodel code from SN %q: %v", kind, s, err)
+		return 0
+	}
+	return code
 }
 
 func (x *xArm) detectVersion(ctx context.Context) (versionInfo, error) {
@@ -170,7 +174,7 @@ func (x *xArm) detectVersion(ctx context.Context) (versionInfo, error) {
 		return versionInfo{}, fmt.Errorf("version response too short: %d (%v)", len(resp.params), resp.params)
 	}
 	banner := strings.TrimRight(string(resp.params[1:]), "\x00 ")
-	v, ok := parseVersionBanner(banner)
+	v, ok := parseVersionBanner(banner, x.logger)
 	if !ok {
 		return versionInfo{}, fmt.Errorf("could not parse version banner: %q", banner)
 	}
@@ -203,8 +207,8 @@ func (x *xArm) detectStandardGripper(ctx context.Context) (detectedGripper, erro
 	}, nil
 }
 
-// standardGripperSubmodel splits at firmware >= 3.4.3, the gate the Python
-// SDK uses for status-reporting support (gripper.py:83-85).
+// standardGripperSubmodel splits at firmware >= 3.4.3, the gate for
+// status-register (0x0000) support on the standard gripper.
 func standardGripperSubmodel(major, minor, patch uint16) string {
 	switch {
 	case major > 3:
@@ -219,7 +223,7 @@ func standardGripperSubmodel(major, minor, patch uint16) string {
 }
 
 // detectBioGripper: byteCount==2 means v1 (single-register response), 2*numRegs
-// means v2 (full SN). Matches xarm_bio.cc:_get_bio_gripper_sn.
+// means v2 (full SN).
 func (x *xArm) detectBioGripper(ctx context.Context) (detectedGripper, error) {
 	const numRegs = 16
 	c := x.gripperPreamble(false)
@@ -299,9 +303,9 @@ func (x *xArm) detectVacuumGripper(ctx context.Context) (detectedGripper, error)
 	}, nil
 }
 
-// vacuumGripperSubmodel infers hardware revision from the arm: xarm-python-sdk
-// gpio.py:117 uses TGPIO outputs 3/4 (v2) for 850 and for xArm6/7 with
-// submodel >= 1305; older xArms use TGPIO 0/1 (v1); Lite 6 has its own bus.
+// vacuumGripperSubmodel infers hardware revision from the arm: TGPIO outputs
+// 3/4 (v2) drive the 850 and xArm6/7 with submodel >= 1305; older xArms use
+// TGPIO 0/1 (v1); Lite 6 has its own bus.
 func vacuumGripperSubmodel(arm detectedArm) string {
 	switch {
 	case arm.Model == hardwareModelLite6:

--- a/arm/detection.go
+++ b/arm/detection.go
@@ -37,6 +37,25 @@ const (
 	gripperKindVacuum   gripperKind = "vacuum"
 )
 
+// Submodel labels reported in detectedGripper.Submodel.
+const (
+	submodelV1   = "v1"
+	submodelV2   = "v2"
+	submodelLite = "lite"
+)
+
+// Two-letter SN prefixes UFactory burns into the controller banner. These are
+// the authoritative model signal — numeric device_type drifts across firmware
+// versions, but the prefix does not.
+const (
+	snPrefixXArm5   = "XF"
+	snPrefixXArm6   = "XI"
+	snPrefixXArm7   = "XS"
+	snPrefixXArm7T  = "CS"
+	snPrefixLite6   = "LI"
+	snPrefixXArm850 = "FX"
+)
+
 // detectedArm is the result of an arm-model probe.
 type detectedArm struct {
 	Model           hardwareModel
@@ -85,17 +104,17 @@ func armModelFromSNPrefix(armTypeStr string) (hardwareModel, byte) {
 		return hardwareModelUnknown, 0
 	}
 	switch armTypeStr[:2] {
-	case "XF":
+	case snPrefixXArm5:
 		return hardwareModelXArm5, 5
-	case "XI":
+	case snPrefixXArm6:
 		return hardwareModelXArm6, 6
-	case "XS":
+	case snPrefixXArm7:
 		return hardwareModelXArm7, 7
-	case "CS":
+	case snPrefixXArm7T:
 		return hardwareModelXArm7T, 7
-	case "LI":
+	case snPrefixLite6:
 		return hardwareModelLite6, 6
-	case "FX":
+	case snPrefixXArm850:
 		return hardwareModelXArm850, 6
 	}
 	return hardwareModelUnknown, 0
@@ -218,13 +237,13 @@ func (x *xArm) detectStandardGripper(ctx context.Context) (detectedGripper, erro
 func standardGripperSubmodel(major, minor, patch uint16) string {
 	switch {
 	case major > 3:
-		return "v2"
+		return submodelV2
 	case major == 3 && minor > 4:
-		return "v2"
+		return submodelV2
 	case major == 3 && minor == 4 && patch >= 3:
-		return "v2"
+		return submodelV2
 	default:
-		return "v1"
+		return submodelV1
 	}
 }
 
@@ -315,12 +334,12 @@ func (x *xArm) detectVacuumGripper(ctx context.Context) (detectedGripper, error)
 func vacuumGripperSubmodel(arm detectedArm) string {
 	switch {
 	case arm.Model == hardwareModelLite6:
-		return "lite"
+		return submodelLite
 	case arm.Model == hardwareModelXArm850:
-		return "v2"
+		return submodelV2
 	case arm.ArmTypeCode >= 1305:
-		return "v2"
+		return submodelV2
 	default:
-		return "v1"
+		return submodelV1
 	}
 }

--- a/arm/detection_test.go
+++ b/arm/detection_test.go
@@ -111,11 +111,11 @@ func TestVacuumGripperSubmodel(t *testing.T) {
 		arm  DetectedArm
 		want string
 	}{
-		{"lite6", DetectedArm{Model: ArmModelLite6}, "lite"},
-		{"850", DetectedArm{Model: ArmModelXArm850}, "v2"},
-		{"xArm6 XI1305", DetectedArm{Model: ArmModelXArm6, ArmTypeCode: 1305}, "v2"},
-		{"xArm6 XI1304", DetectedArm{Model: ArmModelXArm6, ArmTypeCode: 1304}, "v1"},
-		{"xArm7 no submodel info", DetectedArm{Model: ArmModelXArm7}, "v1"},
+		{"lite6", DetectedArm{Model: HardwareModelLite6}, "lite"},
+		{"850", DetectedArm{Model: HardwareModelXArm850}, "v2"},
+		{"xArm6 XI1305", DetectedArm{Model: HardwareModelXArm6, ArmTypeCode: 1305}, "v2"},
+		{"xArm6 XI1304", DetectedArm{Model: HardwareModelXArm6, ArmTypeCode: 1304}, "v1"},
+		{"xArm7 no submodel info", DetectedArm{Model: HardwareModelXArm7}, "v1"},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -124,22 +124,22 @@ func TestVacuumGripperSubmodel(t *testing.T) {
 	}
 }
 
-func TestArmModelFromSNPrefix(t *testing.T) {
+func TestHardwareModelFromSNPrefix(t *testing.T) {
 	tests := []struct {
 		name       string
 		armTypeStr string
-		wantModel  ArmModel
+		wantModel  HardwareModel
 		wantAxis   byte
 	}{
-		{"xArm5 (XF)", "XF1300_2021Sx0001", ArmModelXArm5, 5},
-		{"xArm6 (XI)", "XI1305_2021Sx0001", ArmModelXArm6, 6},
-		{"xArm7 (XS)", "XS1300_2021Sx0001", ArmModelXArm7, 7},
-		{"xArm7T (CS)", "CS1300_2021Sx0001", ArmModelXArm7T, 7},
-		{"lite6 (LI)", "LI1100_2021Sx0001", ArmModelLite6, 6},
-		{"xArm850 (FX)", "FX1200_2021Sx0001", ArmModelXArm850, 6},
-		{"unknown prefix", "ZZ1300_2021Sx0001", ArmModelUnknown, 0},
-		{"empty", "", ArmModelUnknown, 0},
-		{"too short", "X", ArmModelUnknown, 0},
+		{"xArm5 (XF)", "XF1300_2021Sx0001", HardwareModelXArm5, 5},
+		{"xArm6 (XI)", "XI1305_2021Sx0001", HardwareModelXArm6, 6},
+		{"xArm7 (XS)", "XS1300_2021Sx0001", HardwareModelXArm7, 7},
+		{"xArm7T (CS)", "CS1300_2021Sx0001", HardwareModelXArm7T, 7},
+		{"lite6 (LI)", "LI1100_2021Sx0001", HardwareModelLite6, 6},
+		{"xArm850 (FX)", "FX1200_2021Sx0001", HardwareModelXArm850, 6},
+		{"unknown prefix", "ZZ1300_2021Sx0001", HardwareModelUnknown, 0},
+		{"empty", "", HardwareModelUnknown, 0},
+		{"too short", "X", HardwareModelUnknown, 0},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -150,27 +150,27 @@ func TestArmModelFromSNPrefix(t *testing.T) {
 	}
 }
 
-func TestDecodeArmModel(t *testing.T) {
+func TestDecodeHardwareModel(t *testing.T) {
 	tests := []struct {
 		name       string
 		deviceType byte
 		axis       byte
-		want       ArmModel
+		want       HardwareModel
 	}{
-		{"xArm5", 5, 5, ArmModelXArm5},
-		{"xArm6", 6, 6, ArmModelXArm6},
-		{"xArm7", 3, 7, ArmModelXArm7},
-		{"xArm7T", 13, 7, ArmModelXArm7T},
-		{"lite6", 9, 6, ArmModelLite6},
-		{"xArm850", 12, 6, ArmModelXArm850},
-		{"lite6 wrong axis falls back", 9, 7, ArmModelUnknown},
-		{"xArm850 wrong axis falls back", 12, 7, ArmModelUnknown},
-		{"unknown device_type", 99, 6, ArmModelUnknown},
-		{"zero values", 0, 0, ArmModelUnknown},
+		{"xArm5", 5, 5, HardwareModelXArm5},
+		{"xArm6", 6, 6, HardwareModelXArm6},
+		{"xArm7", 3, 7, HardwareModelXArm7},
+		{"xArm7T", 13, 7, HardwareModelXArm7T},
+		{"lite6", 9, 6, HardwareModelLite6},
+		{"xArm850", 12, 6, HardwareModelXArm850},
+		{"lite6 wrong axis falls back", 9, 7, HardwareModelUnknown},
+		{"xArm850 wrong axis falls back", 12, 7, HardwareModelUnknown},
+		{"unknown device_type", 99, 6, HardwareModelUnknown},
+		{"zero values", 0, 0, HardwareModelUnknown},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			got := decodeArmModel(tc.deviceType, tc.axis)
+			got := decodeHardwareModel(tc.deviceType, tc.axis)
 			test.That(t, got, test.ShouldEqual, tc.want)
 		})
 	}

--- a/arm/detection_test.go
+++ b/arm/detection_test.go
@@ -113,11 +113,11 @@ func TestVacuumGripperSubmodel(t *testing.T) {
 		arm  detectedArm
 		want string
 	}{
-		{"lite6", detectedArm{Model: hardwareModelLite6}, "lite"},
-		{"850", detectedArm{Model: hardwareModelXArm850}, "v2"},
-		{"xArm6 XI1305", detectedArm{Model: hardwareModelXArm6, ArmTypeCode: 1305}, "v2"},
-		{"xArm6 XI1304", detectedArm{Model: hardwareModelXArm6, ArmTypeCode: 1304}, "v1"},
-		{"xArm7 no submodel info", detectedArm{Model: hardwareModelXArm7}, "v1"},
+		{"lite6", detectedArm{model: hardwareModelLite6}, "lite"},
+		{"850", detectedArm{model: hardwareModelXArm850}, "v2"},
+		{"xArm6 XI1305", detectedArm{model: hardwareModelXArm6, armTypeCode: 1305}, "v2"},
+		{"xArm6 XI1304", detectedArm{model: hardwareModelXArm6, armTypeCode: 1304}, "v1"},
+		{"xArm7 no submodel info", detectedArm{model: hardwareModelXArm7}, "v1"},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {

--- a/arm/detection_test.go
+++ b/arm/detection_test.go
@@ -1,0 +1,177 @@
+package arm
+
+import (
+	"testing"
+
+	"go.viam.com/test"
+)
+
+func TestParseVersionBanner(t *testing.T) {
+	tests := []struct {
+		name        string
+		banner      string
+		wantOK      bool
+		wantAxis    int
+		wantDevType int
+		wantArmStr  string
+		wantArmCode int
+		wantCtlCode int
+		wantFW      string
+	}{
+		{
+			name:        "xArm6 model 1 (XI1300)",
+			banner:      "1,6,XI1300_2020Sx0001,CI1300_2020Sx0001,v1.10.0",
+			wantOK:      true,
+			wantAxis:    1,
+			wantDevType: 6,
+			wantArmStr:  "XI1300_2020Sx0001",
+			wantArmCode: 1300,
+			wantCtlCode: 1300,
+			wantFW:      "1.10.0",
+		},
+		{
+			name:        "xArm6 model 3 (XI1304)",
+			banner:      "1,6,XI1304_2021Sx0001,CI1300_2021Sx0001,v1.13.20",
+			wantOK:      true,
+			wantAxis:    1,
+			wantDevType: 6,
+			wantArmStr:  "XI1304_2021Sx0001",
+			wantArmCode: 1304,
+			wantCtlCode: 1300,
+			wantFW:      "1.13.20",
+		},
+		{
+			name:        "lite6",
+			banner:      "1,9,LI1100_2021Sx0001,CI1300_2021Sx0001,v1.13.20",
+			wantOK:      true,
+			wantAxis:    1,
+			wantDevType: 9,
+			wantArmStr:  "LI1100_2021Sx0001",
+			wantArmCode: 1100,
+			wantCtlCode: 1300,
+			wantFW:      "1.13.20",
+		},
+		{
+			name:        "no leading v",
+			banner:      "1,6,XI1305_2022Sx0001,CI1300_2022Sx0001,1.14.0",
+			wantOK:      true,
+			wantArmCode: 1305,
+			wantCtlCode: 1300,
+			wantFW:      "1.14.0",
+		},
+		{name: "old protocol firmware (no banner)", banner: "v1.5.0", wantOK: false},
+		{name: "empty", banner: "", wantOK: false},
+		{name: "garbage", banner: "hello world", wantOK: false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := parseVersionBanner(tc.banner)
+			test.That(t, ok, test.ShouldEqual, tc.wantOK)
+			if !tc.wantOK {
+				return
+			}
+			if tc.wantAxis != 0 {
+				test.That(t, got.axis, test.ShouldEqual, tc.wantAxis)
+			}
+			if tc.wantDevType != 0 {
+				test.That(t, got.deviceType, test.ShouldEqual, tc.wantDevType)
+			}
+			if tc.wantArmStr != "" {
+				test.That(t, got.armTypeStr, test.ShouldEqual, tc.wantArmStr)
+			}
+			test.That(t, got.armTypeCode, test.ShouldEqual, tc.wantArmCode)
+			test.That(t, got.controlTypeCode, test.ShouldEqual, tc.wantCtlCode)
+			test.That(t, got.firmwareVersion, test.ShouldEqual, tc.wantFW)
+		})
+	}
+}
+
+func TestStandardGripperSubmodel(t *testing.T) {
+	tests := []struct {
+		name              string
+		major, minor, pat uint16
+		want              string
+	}{
+		{"old major", 2, 9, 9, "v1"},
+		{"3.4.2 just below gate", 3, 4, 2, "v1"},
+		{"3.4.3 exact gate", 3, 4, 3, "v2"},
+		{"3.5.0 above gate", 3, 5, 0, "v2"},
+		{"4.0.0", 4, 0, 0, "v2"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			test.That(t, standardGripperSubmodel(tc.major, tc.minor, tc.pat), test.ShouldEqual, tc.want)
+		})
+	}
+}
+
+func TestVacuumGripperSubmodel(t *testing.T) {
+	tests := []struct {
+		name string
+		arm  DetectedArm
+		want string
+	}{
+		{"lite6", DetectedArm{Model: ArmModelLite6}, "lite"},
+		{"850", DetectedArm{Model: ArmModelXArm850}, "v2"},
+		{"xArm6 XI1305", DetectedArm{Model: ArmModelXArm6, ArmTypeCode: 1305}, "v2"},
+		{"xArm6 XI1304", DetectedArm{Model: ArmModelXArm6, ArmTypeCode: 1304}, "v1"},
+		{"xArm7 no submodel info", DetectedArm{Model: ArmModelXArm7}, "v1"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			test.That(t, vacuumGripperSubmodel(tc.arm), test.ShouldEqual, tc.want)
+		})
+	}
+}
+
+func TestArmModelFromSNPrefix(t *testing.T) {
+	tests := []struct {
+		name       string
+		armTypeStr string
+		wantModel  ArmModel
+		wantAxis   byte
+	}{
+		{"xArm5 (XF)", "XF1300_2021Sx0001", ArmModelXArm5, 5},
+		{"xArm6 (XI)", "XI1305_2021Sx0001", ArmModelXArm6, 6},
+		{"xArm7 (XS)", "XS1300_2021Sx0001", ArmModelXArm7, 7},
+		{"xArm7T (CS)", "CS1300_2021Sx0001", ArmModelXArm7T, 7},
+		{"lite6 (LI)", "LI1100_2021Sx0001", ArmModelLite6, 6},
+		{"xArm850 (FX)", "FX1200_2021Sx0001", ArmModelXArm850, 6},
+		{"unknown prefix", "ZZ1300_2021Sx0001", ArmModelUnknown, 0},
+		{"empty", "", ArmModelUnknown, 0},
+		{"too short", "X", ArmModelUnknown, 0},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			gotModel, gotAxis := armModelFromSNPrefix(tc.armTypeStr)
+			test.That(t, gotModel, test.ShouldEqual, tc.wantModel)
+			test.That(t, gotAxis, test.ShouldEqual, tc.wantAxis)
+		})
+	}
+}
+
+func TestDecodeArmModel(t *testing.T) {
+	tests := []struct {
+		name       string
+		deviceType byte
+		axis       byte
+		want       ArmModel
+	}{
+		{"xArm5", 5, 5, ArmModelXArm5},
+		{"xArm6", 6, 6, ArmModelXArm6},
+		{"xArm7", 3, 7, ArmModelXArm7},
+		{"xArm7T", 13, 7, ArmModelXArm7T},
+		{"lite6", 9, 6, ArmModelLite6},
+		{"xArm850", 12, 6, ArmModelXArm850},
+		{"lite6 wrong axis falls back", 9, 7, ArmModelUnknown},
+		{"xArm850 wrong axis falls back", 12, 7, ArmModelUnknown},
+		{"unknown device_type", 99, 6, ArmModelUnknown},
+		{"zero values", 0, 0, ArmModelUnknown},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := decodeArmModel(tc.deviceType, tc.axis)
+			test.That(t, got, test.ShouldEqual, tc.want)
+		})
+	}
+}

--- a/arm/detection_test.go
+++ b/arm/detection_test.go
@@ -66,11 +66,12 @@ func TestParseVersionBanner(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			got, ok := parseVersionBanner(tc.banner, logging.NewTestLogger(t))
-			test.That(t, ok, test.ShouldEqual, tc.wantOK)
+			got, err := parseVersionBanner(tc.banner, logging.NewTestLogger(t))
 			if !tc.wantOK {
+				test.That(t, err, test.ShouldNotBeNil)
 				return
 			}
+			test.That(t, err, test.ShouldBeNil)
 			if tc.wantAxis != 0 {
 				test.That(t, got.axis, test.ShouldEqual, tc.wantAxis)
 			}

--- a/arm/detection_test.go
+++ b/arm/detection_test.go
@@ -108,14 +108,14 @@ func TestStandardGripperSubmodel(t *testing.T) {
 func TestVacuumGripperSubmodel(t *testing.T) {
 	tests := []struct {
 		name string
-		arm  DetectedArm
+		arm  detectedArm
 		want string
 	}{
-		{"lite6", DetectedArm{Model: HardwareModelLite6}, "lite"},
-		{"850", DetectedArm{Model: HardwareModelXArm850}, "v2"},
-		{"xArm6 XI1305", DetectedArm{Model: HardwareModelXArm6, ArmTypeCode: 1305}, "v2"},
-		{"xArm6 XI1304", DetectedArm{Model: HardwareModelXArm6, ArmTypeCode: 1304}, "v1"},
-		{"xArm7 no submodel info", DetectedArm{Model: HardwareModelXArm7}, "v1"},
+		{"lite6", detectedArm{Model: hardwareModelLite6}, "lite"},
+		{"850", detectedArm{Model: hardwareModelXArm850}, "v2"},
+		{"xArm6 XI1305", detectedArm{Model: hardwareModelXArm6, ArmTypeCode: 1305}, "v2"},
+		{"xArm6 XI1304", detectedArm{Model: hardwareModelXArm6, ArmTypeCode: 1304}, "v1"},
+		{"xArm7 no submodel info", detectedArm{Model: hardwareModelXArm7}, "v1"},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -128,18 +128,18 @@ func TestHardwareModelFromSNPrefix(t *testing.T) {
 	tests := []struct {
 		name       string
 		armTypeStr string
-		wantModel  HardwareModel
+		wantModel  hardwareModel
 		wantAxis   byte
 	}{
-		{"xArm5 (XF)", "XF1300_2021Sx0001", HardwareModelXArm5, 5},
-		{"xArm6 (XI)", "XI1305_2021Sx0001", HardwareModelXArm6, 6},
-		{"xArm7 (XS)", "XS1300_2021Sx0001", HardwareModelXArm7, 7},
-		{"xArm7T (CS)", "CS1300_2021Sx0001", HardwareModelXArm7T, 7},
-		{"lite6 (LI)", "LI1100_2021Sx0001", HardwareModelLite6, 6},
-		{"xArm850 (FX)", "FX1200_2021Sx0001", HardwareModelXArm850, 6},
-		{"unknown prefix", "ZZ1300_2021Sx0001", HardwareModelUnknown, 0},
-		{"empty", "", HardwareModelUnknown, 0},
-		{"too short", "X", HardwareModelUnknown, 0},
+		{"xArm5 (XF)", "XF1300_2021Sx0001", hardwareModelXArm5, 5},
+		{"xArm6 (XI)", "XI1305_2021Sx0001", hardwareModelXArm6, 6},
+		{"xArm7 (XS)", "XS1300_2021Sx0001", hardwareModelXArm7, 7},
+		{"xArm7T (CS)", "CS1300_2021Sx0001", hardwareModelXArm7T, 7},
+		{"lite6 (LI)", "LI1100_2021Sx0001", hardwareModelLite6, 6},
+		{"xArm850 (FX)", "FX1200_2021Sx0001", hardwareModelXArm850, 6},
+		{"unknown prefix", "ZZ1300_2021Sx0001", hardwareModelUnknown, 0},
+		{"empty", "", hardwareModelUnknown, 0},
+		{"too short", "X", hardwareModelUnknown, 0},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -150,23 +150,23 @@ func TestHardwareModelFromSNPrefix(t *testing.T) {
 	}
 }
 
-func TestDecodeHardwareModel(t *testing.T) {
+func TestDecodehardwareModel(t *testing.T) {
 	tests := []struct {
 		name       string
 		deviceType byte
 		axis       byte
-		want       HardwareModel
+		want       hardwareModel
 	}{
-		{"xArm5", 5, 5, HardwareModelXArm5},
-		{"xArm6", 6, 6, HardwareModelXArm6},
-		{"xArm7", 3, 7, HardwareModelXArm7},
-		{"xArm7T", 13, 7, HardwareModelXArm7T},
-		{"lite6", 9, 6, HardwareModelLite6},
-		{"xArm850", 12, 6, HardwareModelXArm850},
-		{"lite6 wrong axis falls back", 9, 7, HardwareModelUnknown},
-		{"xArm850 wrong axis falls back", 12, 7, HardwareModelUnknown},
-		{"unknown device_type", 99, 6, HardwareModelUnknown},
-		{"zero values", 0, 0, HardwareModelUnknown},
+		{"xArm5", 5, 5, hardwareModelXArm5},
+		{"xArm6", 6, 6, hardwareModelXArm6},
+		{"xArm7", 3, 7, hardwareModelXArm7},
+		{"xArm7T", 13, 7, hardwareModelXArm7T},
+		{"lite6", 9, 6, hardwareModelLite6},
+		{"xArm850", 12, 6, hardwareModelXArm850},
+		{"lite6 wrong axis falls back", 9, 7, hardwareModelUnknown},
+		{"xArm850 wrong axis falls back", 12, 7, hardwareModelUnknown},
+		{"unknown device_type", 99, 6, hardwareModelUnknown},
+		{"zero values", 0, 0, hardwareModelUnknown},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {

--- a/arm/detection_test.go
+++ b/arm/detection_test.go
@@ -3,6 +3,7 @@ package arm
 import (
 	"testing"
 
+	"go.viam.com/rdk/logging"
 	"go.viam.com/test"
 )
 
@@ -65,7 +66,7 @@ func TestParseVersionBanner(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			got, ok := parseVersionBanner(tc.banner)
+			got, ok := parseVersionBanner(tc.banner, logging.NewTestLogger(t))
 			test.That(t, ok, test.ShouldEqual, tc.wantOK)
 			if !tc.wantOK {
 				return

--- a/arm/error.go
+++ b/arm/error.go
@@ -38,8 +38,7 @@ var servoErrorMap = map[byte]string{
 }
 
 // armBoxErrorMap maps controller error codes (decimal in UFactory docs, hex
-// on the wire) to human-readable descriptions. Source:
-// https://github.com/xArm-Developer/xArm-Python-SDK/blob/master/doc/api/xarm_api_code.md
+// on the wire) to human-readable descriptions.
 var armBoxErrorMap = map[byte]string{
 	0x01:             "xArm: Emergency Stop Button Pushed In",
 	0x02:             "xArm: Emergency IO Triggered",
@@ -84,8 +83,7 @@ var armBoxErrorMap = map[byte]string{
 }
 
 // armBoxWarnMap maps controller warning codes (decimal in UFactory docs, hex
-// on the wire) to human-readable descriptions. Source:
-// https://github.com/xArm-Developer/xArm-Python-SDK/blob/master/doc/api/xarm_api_code.md
+// on the wire) to human-readable descriptions.
 var armBoxWarnMap = map[byte]string{
 	0x0B: "xArm Warning: Buffer Overflow",
 	0x0C: "xArm Warning: Command Parameter Abnormal",

--- a/arm/gripper.go
+++ b/arm/gripper.go
@@ -77,6 +77,8 @@ type myGripperLite struct {
 	arm      arm.Arm
 	isMoving atomic.Bool
 
+	detected DetectedGripper
+
 	logger logging.Logger
 }
 
@@ -96,6 +98,8 @@ func newGripperLite(ctx context.Context, deps resource.Dependencies, config reso
 	if err != nil {
 		return nil, err
 	}
+
+	g.detected = probeGripper(ctx, g.arm, GripperKindBio, logger)
 
 	return g, nil
 }
@@ -223,6 +227,8 @@ type myGripper struct {
 	goToPositionLock sync.Mutex
 	isMoving         atomic.Bool
 
+	detected DetectedGripper
+
 	logger logging.Logger
 }
 
@@ -242,6 +248,8 @@ func newGripper(ctx context.Context, deps resource.Dependencies, config resource
 	if err != nil {
 		return nil, err
 	}
+
+	g.detected = probeGripper(ctx, g.arm, GripperKindStandard, logger)
 
 	if newConf.GripperSpeed != 0 {
 		if _, err := g.arm.DoCommand(ctx, map[string]any{

--- a/arm/gripper.go
+++ b/arm/gripper.go
@@ -77,7 +77,7 @@ type myGripperLite struct {
 	arm      arm.Arm
 	isMoving atomic.Bool
 
-	detected DetectedGripper
+	detected detectedGripper
 
 	logger logging.Logger
 }
@@ -99,7 +99,7 @@ func newGripperLite(ctx context.Context, deps resource.Dependencies, config reso
 		return nil, err
 	}
 
-	g.detected = probeGripper(ctx, g.arm, GripperKindBio, logger)
+	g.detected = probeGripper(ctx, g.arm, gripperKindBio, logger)
 
 	return g, nil
 }
@@ -227,7 +227,7 @@ type myGripper struct {
 	goToPositionLock sync.Mutex
 	isMoving         atomic.Bool
 
-	detected DetectedGripper
+	detected detectedGripper
 
 	logger logging.Logger
 }
@@ -249,7 +249,7 @@ func newGripper(ctx context.Context, deps resource.Dependencies, config resource
 		return nil, err
 	}
 
-	g.detected = probeGripper(ctx, g.arm, GripperKindStandard, logger)
+	g.detected = probeGripper(ctx, g.arm, gripperKindStandard, logger)
 
 	if newConf.GripperSpeed != 0 {
 		if _, err := g.arm.DoCommand(ctx, map[string]any{

--- a/arm/vacuum_gripper.go
+++ b/arm/vacuum_gripper.go
@@ -57,7 +57,7 @@ func newVacuumGripper(ctx context.Context, deps resource.Dependencies, config re
 		return nil, err
 	}
 
-	g.detected = probeGripper(ctx, g.arm, GripperKindVacuum, logger)
+	g.detected = probeGripper(ctx, g.arm, gripperKindVacuum, logger)
 
 	return g, nil
 }
@@ -73,7 +73,7 @@ type myVacuumGripper struct {
 
 	isMoving atomic.Bool
 
-	detected DetectedGripper
+	detected detectedGripper
 
 	logger logging.Logger
 }

--- a/arm/vacuum_gripper.go
+++ b/arm/vacuum_gripper.go
@@ -57,6 +57,8 @@ func newVacuumGripper(ctx context.Context, deps resource.Dependencies, config re
 		return nil, err
 	}
 
+	g.detected = probeGripper(ctx, g.arm, GripperKindVacuum, logger)
+
 	return g, nil
 }
 
@@ -70,6 +72,8 @@ type myVacuumGripper struct {
 	arm arm.Arm
 
 	isMoving atomic.Bool
+
+	detected DetectedGripper
 
 	logger logging.Logger
 }

--- a/arm/xarm.go
+++ b/arm/xarm.go
@@ -446,14 +446,14 @@ func NewXArm(ctx context.Context, name resource.Name,
 		logger.Warnf("xArm hardware detection failed: %v", err)
 	} else {
 		x.detectedArm = d
-		if d.ArmTypeCode != 0 {
+		if d.armTypeCode != 0 {
 			logger.Infof(
 				"xArm hardware detected: model=%s axis=%d device_type=%d submodel=%s arm_type=%d control_type=%d fw=%s (configured as %s)",
-				d.Model, d.Axis, d.DeviceType, d.Submodel, d.ArmTypeCode, d.ControlTypeCode, d.FirmwareVersion, modelName,
+				d.model, d.axis, d.deviceType, d.submodel, d.armTypeCode, d.controlTypeCode, d.firmwareVersion, modelName,
 			)
 		} else {
 			logger.Infof("xArm hardware detected: model=%s axis=%d device_type=%d (configured as %s)",
-				d.Model, d.Axis, d.DeviceType, modelName)
+				d.model, d.axis, d.deviceType, modelName)
 		}
 	}
 

--- a/arm/xarm.go
+++ b/arm/xarm.go
@@ -164,7 +164,7 @@ type xArm struct {
 	speed        float64    // speed=max joint radians per second
 	acceleration float64    // acceleration= joint radians per second increase per second
 
-	detectedArm DetectedArm
+	detectedArm detectedArm
 }
 
 func init() {

--- a/arm/xarm.go
+++ b/arm/xarm.go
@@ -163,6 +163,8 @@ type xArm struct {
 	confLock     sync.Mutex // speed and acceleration are both able to be read/written to, so they need to be protected by a mutex
 	speed        float64    // speed=max joint radians per second
 	acceleration float64    // acceleration= joint radians per second increase per second
+
+	detectedArm DetectedArm
 }
 
 func init() {
@@ -438,6 +440,21 @@ func NewXArm(ctx context.Context, name resource.Name,
 	} else {
 		x.gripperConn = gripperConn
 		logger.Infof("gripper Modbus traffic routed through dedicated port %d", defaultGripperPort)
+	}
+
+	if d, err := x.detectArm(ctx); err != nil {
+		logger.Warnf("xArm hardware detection failed: %v", err)
+	} else {
+		x.detectedArm = d
+		if d.ArmTypeCode != 0 {
+			logger.Infof(
+				"xArm hardware detected: model=%s axis=%d device_type=%d submodel=%s arm_type=%d control_type=%d fw=%s (configured as %s)",
+				d.Model, d.Axis, d.DeviceType, d.Submodel, d.ArmTypeCode, d.ControlTypeCode, d.FirmwareVersion, modelName,
+			)
+		} else {
+			logger.Infof("xArm hardware detected: model=%s axis=%d device_type=%d (configured as %s)",
+				d.Model, d.Axis, d.DeviceType, modelName)
+		}
 	}
 
 	err = x.start(ctx, false)


### PR DESCRIPTION
## Summary

  Connect-time hardware detection for the xArm driver.

  **Arm**: parses `GET_VERSION (0x01)` banner, derives model from SN prefix (`XI`/`XF`/`XS`/`CS`/`LI`/`FX`), records submodel + arm-type + control-box + firmware on `xArm.detectedArm`.

  **Grippers**: each resource probes on construction:
  - Standard: firmware version + `v1`/`v2` (gate `>= 3.4.3`)
  - Bio: `v1`/`v2` from byte-count
  - Vacuum: tgpio `0x0A18` presence, `v1`/`v2`/`lite` inferred from arm submodel

  ## Why

  Groundwork for per-submodel kinematics. xArm 6 has 4+ hardware revisions (`XI1300/1304/1305/1380`) with different meshes and joint origins; standard and bio grippers each have v1/v2 with different behavior and geometries.
  Later PRs can read `detectedArm.ArmTypeCode` / `DetectedGripper.Submodel` to pick the right kinematics.