### PR TITLE
Add set_collision_sensitivity DoCommand for runtime control

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,34 @@ xArmComponent.DoCommand(ctx, map[string]interface{}{
 await arm.do_command({"set_speed": 50.0, "set_acceleration": 100.0})
 ```
 
+### Collision Sensitivity
+
+Adjusts the arm's hardware collision detection at runtime, overriding the `collision_sensitivity`
+config value for the rest of the session. The value must be an integer from `0` (detection off) to
+`5` (most sensitive); higher values trigger the emergency stop with less force.
+
+This is useful when some moves deliberately make contact (for example pressing a physical button)
+while others should stop on any unexpected contact: lower the sensitivity (or set `0`) before a
+contact move, and raise it before a free-space move.
+
+The command returns an error if the arm is currently moving — set the sensitivity between moves, not
+during one. The setting is not persisted; the configured `collision_sensitivity` is restored on the
+next restart.
+
+**Go:**
+```go
+// Disable collision detection before a move that intentionally makes contact.
+xArmComponent.DoCommand(ctx, map[string]interface{}{"set_collision_sensitivity": 0})
+
+// Re-enable it before a free-space move.
+xArmComponent.DoCommand(ctx, map[string]interface{}{"set_collision_sensitivity": 3})
+```
+
+**Python:**
+```python
+await arm.do_command({"set_collision_sensitivity": 0})
+```
+
 ### Joint Torques
 
 ```go

--- a/arm/xarm.go
+++ b/arm/xarm.go
@@ -42,25 +42,26 @@ const (
 	defaultTrajGenWaypointDeduplicationToleranceRads = 1e-3
 
 	// DoCommand keys.
-	loadKey                  = "load"
-	moveGripperKey           = "move_gripper"
-	getGripperKey            = "get_gripper"
-	gripperPositionKey       = "gripper_position"
-	setAcckey                = "set_acceleration"
-	setSpeedKey              = "set_speed"
-	grabVacuumKey            = "grab_vacuum"
-	openVacuumKey            = "open_vacuum"
-	clearErrorKey            = "clear_error"
-	getStateKey              = "get_state"
-	getErrorKey              = "get_error"
-	getVacuumGripperStateKey = "get_vacuum_state"
-	vacuumGripperStateKey    = "vacuum_state"
-	gripperLiteActionKey     = "gripper_lite_action"
-	setGripperSpeedKey       = "set_gripper_speed"
-	getGripperSpeedKey       = "get_gripper_speed"
-	gripperSpeedKey          = "gripper_speed"
-	enterManualModeKey       = "enter_manual_mode"
-	exitManualModeKey        = "exit_manual_mode"
+	loadKey                    = "load"
+	moveGripperKey             = "move_gripper"
+	getGripperKey              = "get_gripper"
+	gripperPositionKey         = "gripper_position"
+	setAcckey                  = "set_acceleration"
+	setSpeedKey                = "set_speed"
+	grabVacuumKey              = "grab_vacuum"
+	openVacuumKey              = "open_vacuum"
+	clearErrorKey              = "clear_error"
+	getStateKey                = "get_state"
+	getErrorKey                = "get_error"
+	getVacuumGripperStateKey   = "get_vacuum_state"
+	vacuumGripperStateKey      = "vacuum_state"
+	gripperLiteActionKey       = "gripper_lite_action"
+	setGripperSpeedKey         = "set_gripper_speed"
+	getGripperSpeedKey         = "get_gripper_speed"
+	gripperSpeedKey            = "gripper_speed"
+	enterManualModeKey         = "enter_manual_mode"
+	exitManualModeKey          = "exit_manual_mode"
+	setCollisionSensitivityKey = "set_collision_sensitivity"
 
 	// gripperLiteActionKeys.
 	gripperLiteActionOpen     = "open"
@@ -745,6 +746,31 @@ func (x *xArm) DoCommand(ctx context.Context, cmd map[string]any) (map[string]an
 		x.confLock.Lock()
 		x.acceleration = utils.DegToRad(acceleration)
 		x.confLock.Unlock()
+		validCommand = true
+	}
+	if val, ok := cmd[setCollisionSensitivityKey]; ok {
+		sensitivity, err := utils.AssertType[float64](val)
+		if err != nil {
+			return nil, err
+		}
+		// The arm only accepts whole-number sensitivity levels in [0, 5];
+		// 0 disables collision detection, 5 is the most sensitive.
+		level := int(sensitivity)
+		if float64(level) != sensitivity || level < 0 || level > 5 {
+			return nil, fmt.Errorf("collision sensitivity must be an integer between 0 and 5, got %v", val)
+		}
+		// Refuse while moving: changing the threshold mid-trajectory could race
+		// with the in-flight motion commands, so callers must set it between moves.
+		moving, err := x.IsMoving(ctx)
+		if err != nil {
+			return nil, err
+		}
+		if moving {
+			return nil, errors.New("cannot set collision sensitivity while the arm is moving")
+		}
+		if err := x.setCollisionDetectionSensitivity(ctx, level); err != nil {
+			return nil, err
+		}
 		validCommand = true
 	}
 	if _, ok := cmd[grabVacuumKey]; ok {


### PR DESCRIPTION
Allow adjusting the arm's hardware collision detection at runtime via DoCommand, overriding the configured collision_sensitivity for the rest of the session. This supports workflows where some moves deliberately make contact (e.g. pressing a button) while others should stop on any unexpected contact: set a low/zero sensitivity before a contact move and raise it before a free-space move.

The command validates the level is an integer in [0, 5] and returns an error if the arm is currently moving, so the threshold is only changed between moves. The value is not persisted; the configured default is restored on restart.