### PR TITLE
Add per-move collision_sensitivity override to move APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,33 @@ Copy and paste the following attributes into your JSON configuration:
 | `ufactory-studio-proxy` | bool | Optional | `false` | When `true`, starts a local reverse proxy to the arm's UFactory Studio web UI. See [UFactory Studio Proxy](#ufactory-studio-proxy). |
 | `ufactory-studio-proxy-port` | int | Optional | `18333` | Local port for the Studio proxy. |
 
+#### Per-Move Collision Sensitivity
+
+The move APIs (`MoveToPosition`, `MoveToJointPositions`, and `MoveThroughJointPositions`) accept a
+`collision_sensitivity` value in their `extra` map to override the configured
+`collision_sensitivity` for the duration of that move. The value must be an integer from `0`
+(detection off) to `5` (most sensitive). The arm's collision detection is set to that level before
+the move starts and restored to the configured value (or the firmware default of `3` if none is
+configured) once the move completes — including when the move fails.
+
+This is useful when some moves deliberately make contact (for example pressing a physical button)
+while others should stop on any unexpected contact:
+
+**Go:**
+```go
+// Move that intentionally makes contact: disable detection for this move only.
+xArmComponent.MoveToPosition(ctx, pressPose, map[string]interface{}{"collision_sensitivity": 0})
+
+// Free-space move: stop on any unexpected contact.
+xArmComponent.MoveToJointPositions(ctx, travelInputs, map[string]interface{}{"collision_sensitivity": 3})
+```
+
+**Python:**
+```python
+await arm.move_to_position(press_pose, extra={"collision_sensitivity": 0})
+await arm.move_to_joint_positions(travel_positions, extra={"collision_sensitivity": 3})
+```
+
 ### Networking
 
 #### Connecting using macOS

--- a/arm/comm.go
+++ b/arm/comm.go
@@ -493,12 +493,24 @@ func (x *xArm) Close(ctx context.Context) error {
 	return err
 }
 
+// MoveThroughJointPositions moves the arm through the given joint waypoints.
+//
+// Like MoveToPosition, a "collision_sensitivity" value in extra overrides the
+// arm's hardware collision detection for the duration of the move and is
+// restored afterwards. This also covers MoveToJointPositions, which delegates
+// here. See applyCollisionSensitivityOverride.
 func (x *xArm) MoveThroughJointPositions(
 	ctx context.Context,
 	positions [][]referenceframe.Input,
 	opts *arm.MoveOptions,
 	extra map[string]any,
-) error {
+) (err error) {
+	restore, err := x.applyCollisionSensitivityOverride(ctx, extra)
+	if err != nil {
+		return err
+	}
+	defer restore(&err)
+
 	mo := x.moveOptions(opts, extra)
 	return x.internalMoveThroughJointPositions(ctx, positions, mo)
 }
@@ -868,12 +880,23 @@ func (x *xArm) EndPosition(ctx context.Context, extra map[string]any) (spatialma
 }
 
 // MoveToPosition moves the arm to the specified cartesian position.
-func (x *xArm) MoveToPosition(ctx context.Context, pos spatialmath.Pose, extra map[string]any) error {
+//
+// When extra contains a "collision_sensitivity" value (integer 0-5), the arm's
+// hardware collision detection is set to that level for the duration of the
+// move and restored to the configured baseline once the move completes. See
+// applyCollisionSensitivityOverride.
+func (x *xArm) MoveToPosition(ctx context.Context, pos spatialmath.Pose, extra map[string]any) (err error) {
 	if x.motion == nil {
 		return fmt.Errorf("xarm cannot do MoveToPosition without speficying a motion service")
 	}
 
-	_, err := x.motion.Move(
+	restore, err := x.applyCollisionSensitivityOverride(ctx, extra)
+	if err != nil {
+		return err
+	}
+	defer restore(&err)
+
+	_, err = x.motion.Move(
 		ctx,
 		motion.MoveReq{
 			ComponentName: x.Name().Name,
@@ -881,6 +904,78 @@ func (x *xArm) MoveToPosition(ctx context.Context, pos spatialmath.Pose, extra m
 		},
 	)
 	return err
+}
+
+// collisionSensitivityKey is the extra attribute carrying a per-move collision
+// sensitivity override for the MoveTo* functions.
+const collisionSensitivityKey = "collision_sensitivity"
+
+// defaultCollisionSensitivity is the xArm firmware default, used as the restore
+// baseline when no collision_sensitivity is set in the component configuration.
+const defaultCollisionSensitivity = 3
+
+// applyCollisionSensitivityOverride reads an optional per-move collision
+// sensitivity override from extra and, if present, applies it to the arm. It
+// returns a restore function (always non-nil, safe to defer) that resets the
+// arm to the configured baseline once the move finishes; when no override was
+// present the restore is a no-op. The restore appends any failure to the error
+// it is given, so callers defer it with a pointer to their named return value.
+func (x *xArm) applyCollisionSensitivityOverride(ctx context.Context, extra map[string]any) (func(*error), error) {
+	noop := func(*error) {}
+
+	override, hasOverride, err := parseSensitivityOverride(extra)
+	if err != nil {
+		return noop, err
+	}
+	if !hasOverride {
+		return noop, nil
+	}
+	if err := x.setCollisionDetectionSensitivity(ctx, override); err != nil {
+		return noop, fmt.Errorf("failed to apply collision sensitivity override %d: %w", override, err)
+	}
+
+	return func(errp *error) {
+		// If the move's context was cancelled we still need a live context to
+		// issue the restore, so fall back to a short-lived one.
+		restoreCtx := ctx
+		if restoreCtx.Err() != nil {
+			var cancel context.CancelFunc
+			restoreCtx, cancel = context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+		}
+		baseline := x.baselineCollisionSensitivity()
+		if rErr := x.setCollisionDetectionSensitivity(restoreCtx, baseline); rErr != nil {
+			*errp = multierr.Append(*errp, fmt.Errorf("failed to restore collision sensitivity to %d: %w", baseline, rErr))
+		}
+	}, nil
+}
+
+// parseSensitivityOverride reads an optional "collision_sensitivity" override
+// from a move's extra map. It returns the level, whether one was present, and
+// an error if the value is malformed. Values must be whole numbers in [0, 5].
+func parseSensitivityOverride(extra map[string]any) (int, bool, error) {
+	raw, ok := extra[collisionSensitivityKey]
+	if !ok {
+		return 0, false, nil
+	}
+	f, ok := raw.(float64)
+	if !ok {
+		return 0, false, fmt.Errorf("%s must be a number, got %T", collisionSensitivityKey, raw)
+	}
+	level := int(f)
+	if float64(level) != f || level < 0 || level > 5 {
+		return 0, false, fmt.Errorf("%s must be an integer between 0 and 5, got %v", collisionSensitivityKey, raw)
+	}
+	return level, true, nil
+}
+
+// baselineCollisionSensitivity is the level restored after a per-move override:
+// the configured value if set, otherwise the firmware default.
+func (x *xArm) baselineCollisionSensitivity() int {
+	if x.conf != nil && x.conf.Sensitivity != nil {
+		return *x.conf.Sensitivity
+	}
+	return defaultCollisionSensitivity
 }
 
 // JointPositions returns the current positions of all joints.

--- a/arm/comm_test.go
+++ b/arm/comm_test.go
@@ -41,7 +41,7 @@ func TestParseSensitivityOverride(t *testing.T) {
 	test.That(t, level, test.ShouldEqual, 0)
 
 	// Nil extra behaves like absent.
-	level, ok, err = parseSensitivityOverride(nil)
+	_, ok, err = parseSensitivityOverride(nil)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, ok, test.ShouldBeFalse)
 

--- a/arm/comm_test.go
+++ b/arm/comm_test.go
@@ -1,6 +1,7 @@
 package arm
 
 import (
+	"context"
 	"testing"
 
 	"go.viam.com/rdk/logging"
@@ -30,4 +31,72 @@ func TestCreateRawJointSteps1(t *testing.T) {
 	minMoves := (1 / x.speed) * x.moveHZ
 	test.That(t, len(out), test.ShouldBeGreaterThan, minMoves)
 	test.That(t, len(out), test.ShouldBeLessThan, 20+minMoves)
+}
+
+func TestParseSensitivityOverride(t *testing.T) {
+	// Absent key: no override, no error.
+	level, ok, err := parseSensitivityOverride(map[string]any{})
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, ok, test.ShouldBeFalse)
+	test.That(t, level, test.ShouldEqual, 0)
+
+	// Nil extra behaves like absent.
+	level, ok, err = parseSensitivityOverride(nil)
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, ok, test.ShouldBeFalse)
+
+	// Valid values across the whole range (JSON numbers arrive as float64).
+	for _, v := range []float64{0, 1, 3, 5} {
+		level, ok, err = parseSensitivityOverride(map[string]any{collisionSensitivityKey: v})
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, ok, test.ShouldBeTrue)
+		test.That(t, level, test.ShouldEqual, int(v))
+	}
+
+	// Out of range.
+	_, _, err = parseSensitivityOverride(map[string]any{collisionSensitivityKey: 6.0})
+	test.That(t, err, test.ShouldNotBeNil)
+	_, _, err = parseSensitivityOverride(map[string]any{collisionSensitivityKey: -1.0})
+	test.That(t, err, test.ShouldNotBeNil)
+
+	// Non-integer.
+	_, _, err = parseSensitivityOverride(map[string]any{collisionSensitivityKey: 2.5})
+	test.That(t, err, test.ShouldNotBeNil)
+
+	// Wrong type.
+	_, _, err = parseSensitivityOverride(map[string]any{collisionSensitivityKey: "3"})
+	test.That(t, err, test.ShouldNotBeNil)
+}
+
+func TestApplyCollisionSensitivityOverrideNoHardware(t *testing.T) {
+	x := &xArm{conf: &Config{}}
+
+	// No override present: restore is a no-op that touches no hardware and
+	// reports no error.
+	restore, err := x.applyCollisionSensitivityOverride(context.Background(), nil)
+	test.That(t, err, test.ShouldBeNil)
+	moveErr := error(nil)
+	restore(&moveErr)
+	test.That(t, moveErr, test.ShouldBeNil)
+
+	// Malformed override: error is returned before any hardware command, and
+	// the returned restore is still safe to call.
+	restore, err = x.applyCollisionSensitivityOverride(context.Background(), map[string]any{collisionSensitivityKey: "bad"})
+	test.That(t, err, test.ShouldNotBeNil)
+	moveErr = nil
+	restore(&moveErr)
+	test.That(t, moveErr, test.ShouldBeNil)
+}
+
+func TestBaselineCollisionSensitivity(t *testing.T) {
+	// No configured value falls back to the firmware default.
+	x := &xArm{conf: &Config{}}
+	test.That(t, x.baselineCollisionSensitivity(), test.ShouldEqual, defaultCollisionSensitivity)
+
+	// Configured value (including 0 = off) is honored.
+	for _, v := range []int{0, 2, 5} {
+		val := v
+		x := &xArm{conf: &Config{Sensitivity: &val}}
+		test.That(t, x.baselineCollisionSensitivity(), test.ShouldEqual, v)
+	}
 }


### PR DESCRIPTION
MoveToPosition, MoveToJointPositions, and MoveThroughJointPositions now accept a "collision_sensitivity" value in their extra map. When present, the arm's hardware collision detection is set to that level (integer 0-5) before the move and restored to the configured baseline once the move completes, including on failure.

This supports workflows where some moves deliberately make contact (e.g. pressing a button) while others should stop on any unexpected contact, without changing the component configuration.

The apply/restore logic lives in a shared applyCollisionSensitivityOverride helper. MoveToJointPositions is covered via its delegation to MoveThroughJointPositions, and the motion service's GoToInputs execution path passes nil extra, so MoveToPosition overrides are applied exactly once.