### PR TITLE
Add 6-axis Force/Torque sensor resource (viam:ufactory:ft_sensor)

### DIFF
--- a/README.md
+++ b/README.md
@@ -370,9 +370,7 @@ Model `viam:ufactory:ft_sensor` exposes the UFactory wrist-mounted 6-axis
 Force/Torque sensor as a Viam `sensor`. It depends on a configured xArm and reads
 through the arm's controller connection. Requires controller firmware >= 1.8.3.
 
-**Supported arms:** `xArm6`, `xArm7`, and `xArm850`. The `lite6` is **not** supported —
-UFACTORY does not offer this sensor for the Lite 6 (and at 445 g it would exceed the
-Lite 6's payload). Configuring this sensor against a Lite 6 will result in failed reads.
+**Supported arms:** `xArm6`, `xArm7`, and `xArm850`. The `lite6` is not supported.
 
 > **Prerequisite:** The sensor must be **enabled and calibrated in UFactory Studio
 > before use** (Externals → Torque Sensor: confirm a real SN/firmware appear, then run

--- a/README.md
+++ b/README.md
@@ -370,6 +370,10 @@ Model `viam:ufactory:ft_sensor` exposes the UFactory wrist-mounted 6-axis
 Force/Torque sensor as a Viam `sensor`. It depends on a configured xArm and reads
 through the arm's controller connection. Requires controller firmware >= 1.8.3.
 
+**Supported arms:** `xArm6`, `xArm7`, and `xArm850`. The `lite6` is **not** supported —
+UFACTORY does not offer this sensor for the Lite 6 (and at 445 g it would exceed the
+Lite 6's payload). Configuring this sensor against a Lite 6 will result in failed reads.
+
 > **Prerequisite:** The sensor must be **enabled and calibrated in UFactory Studio
 > before use** (Externals → Torque Sensor: confirm a real SN/firmware appear, then run
 > payload identification / zeroing). This module only reads the sensor; it does not

--- a/README.md
+++ b/README.md
@@ -364,6 +364,45 @@ Vacuum gripper for the Lite 6.
 }
 ```
 
+## Force Torque Sensor
+
+Model `viam:ufactory:ft_sensor` exposes the UFactory wrist-mounted 6-axis
+Force/Torque sensor as a Viam `sensor`. It depends on a configured xArm and reads
+through the arm's controller connection. Requires controller firmware >= 1.8.3.
+
+### Configuration
+
+```json
+{
+  "arm": "my-xarm",
+  "enable_on_start": false
+}
+```
+
+| Attribute         | Type   | Required | Description |
+|-------------------|--------|----------|-------------|
+| `arm`             | string | yes      | Name of the xArm this sensor is attached to. |
+| `enable_on_start` | bool   | no       | Enable the sensor when the resource starts. Default `false`. Leave `false` if you enabled the sensor in UFactory Studio (that setting persists on the controller); set `true` if you did not, so readings work without a manual `DoCommand`. |
+
+### Readings
+
+`GetReadings` returns the same keys and units as the Universal Robots F/T sensor:
+
+```json
+{ "Fx_N": -0.987, "Fy_N": -2.923, "Fz_N": -18.356,
+  "TRx_Nm": -0.0012, "TRy_Nm": -0.0914, "TRz_Nm": 0.00698 }
+```
+
+Forces (`F*_N`) are in newtons; torques (`TR*_Nm`) are in newton-metres.
+
+### DoCommand
+
+| Command | Effect |
+|---------|--------|
+| `{"enable": true}` | Enable the sensor (required before taring/reading). |
+| `{"enable": false}` | Disable the sensor. |
+| `{"tare": true}` | Zero the sensor at the current reading. Hold the arm stationary at the unloaded reference pose first. |
+
 ## UFactory xArm Resources
 
 - [UFactory xArm User Manual](https://www.ufactory.cc/wp-content/uploads/2023/05/xArm-User-Manual-V2.0.0.pdf)

--- a/README.md
+++ b/README.md
@@ -370,37 +370,40 @@ Model `viam:ufactory:ft_sensor` exposes the UFactory wrist-mounted 6-axis
 Force/Torque sensor as a Viam `sensor`. It depends on a configured xArm and reads
 through the arm's controller connection. Requires controller firmware >= 1.8.3.
 
+> **Prerequisite:** The sensor must be **enabled and calibrated in UFactory Studio
+> before use** (Externals → Torque Sensor: confirm a real SN/firmware appear, then run
+> payload identification / zeroing). This module only reads the sensor; it does not
+> enable or commission it. If the sensor is not enabled and calibrated, reads will
+> fail or return meaningless values.
+
 ### Configuration
 
 ```json
 {
-  "arm": "my-xarm",
-  "enable_on_start": false
+  "arm": "my-xarm"
 }
 ```
 
-| Attribute         | Type   | Required | Description |
-|-------------------|--------|----------|-------------|
-| `arm`             | string | yes      | Name of the xArm this sensor is attached to. |
-| `enable_on_start` | bool   | no       | Enable the sensor when the resource starts. Default `false`. Leave `false` if you enabled the sensor in UFactory Studio (that setting persists on the controller); set `true` if you did not, so readings work without a manual `DoCommand`. |
+| Attribute | Type   | Required | Description |
+|-----------|--------|----------|-------------|
+| `arm`     | string | yes      | Name of the xArm this sensor is attached to. |
 
 ### Readings
 
-`GetReadings` returns the same keys and units as the Universal Robots F/T sensor:
+`GetReadings` returns the six force/torque values keyed with their units:
 
 ```json
 { "Fx_N": -0.987, "Fy_N": -2.923, "Fz_N": -18.356,
   "TRx_Nm": -0.0012, "TRy_Nm": -0.0914, "TRz_Nm": 0.00698 }
 ```
 
-Forces (`F*_N`) are in newtons; torques (`TR*_Nm`) are in newton-metres.
+Forces (`Fx_N`, `Fy_N`, `Fz_N`) are in newtons; torques (`TRx_Nm`, `TRy_Nm`,
+`TRz_Nm`) are in newton-metres.
 
 ### DoCommand
 
 | Command | Effect |
 |---------|--------|
-| `{"enable": true}` | Enable the sensor (required before taring/reading). |
-| `{"enable": false}` | Disable the sensor. |
 | `{"tare": true}` | Zero the sensor at the current reading. Hold the arm stationary at the unloaded reference pose first. |
 
 ## UFactory xArm Resources

--- a/arm/comm.go
+++ b/arm/comm.go
@@ -48,6 +48,9 @@ var regMap = map[string]byte{
 	"SetBound":       0x34,
 	"EnableBound":    0x34,
 	"CurrentTorque":  0x37,
+	"FTSensorData":   0xC8,
+	"FTSensorEnable": 0xC9,
+	"FTSensorZero":   0xCE,
 	"SetEEModel":     0x4E,
 	"ServoError":     0x6A,
 	"GripperControl": 0x7C,
@@ -1220,6 +1223,57 @@ func (x *xArm) getLoad(ctx context.Context) ([]float64, error) {
 	}
 
 	return loads, nil
+}
+
+// ftSensorValueCount is the number of values the 6-axis F/T sensor returns:
+// Fx, Fy, Fz, Tx, Ty, Tz.
+const ftSensorValueCount = 6
+
+// parseFTSensorData parses the controller response for FTSensorData (0xC8).
+// params[0] is a leading status byte; the six float32 values follow, little-endian,
+// at offset i*4+1 (same layout as getLoad / JointPositions).
+func parseFTSensorData(params []byte) ([]float64, error) {
+	need := 1 + ftSensorValueCount*4
+	if len(params) < need {
+		return nil, fmt.Errorf("unexpected F/T sensor response length, got %d want >= %d", len(params), need)
+	}
+	vals := make([]float64, 0, ftSensorValueCount)
+	for i := range ftSensorValueCount {
+		idx := i*4 + 1
+		vals = append(vals, float64(rutils.Float32FromBytesLE(params[idx:idx+4])))
+	}
+	return vals, nil
+}
+
+// getFTSensorData reads the wrist 6-axis F/T sensor: [Fx, Fy, Fz, Tx, Ty, Tz].
+func (x *xArm) getFTSensorData(ctx context.Context) ([]float64, error) {
+	c := x.newCmd(regMap["FTSensorData"])
+	resp, err := x.send(ctx, c, true)
+	if err != nil {
+		return nil, err
+	}
+	return parseFTSensorData(resp.params)
+}
+
+// setFTSensorEnable enables or disables the 6-axis F/T sensor.
+func (x *xArm) setFTSensorEnable(ctx context.Context, enable bool) error {
+	c := x.newCmd(regMap["FTSensorEnable"])
+	var b byte
+	if enable {
+		b = 0x01
+	}
+	c.params = append(c.params, b)
+	_, err := x.send(ctx, c, true)
+	return err
+}
+
+// setFTSensorZero tares the sensor: the controller snapshots the current reading as
+// the offset subtracted from all subsequent reads. The arm should be stationary at
+// the reference pose/payload and the sensor must be enabled first.
+func (x *xArm) setFTSensorZero(ctx context.Context) error {
+	c := x.newCmd(regMap["FTSensorZero"])
+	_, err := x.send(ctx, c, true)
+	return err
 }
 
 func (x *xArm) setCollisionDetectionSensitivity(ctx context.Context, sensitivity int) error {

--- a/arm/comm.go
+++ b/arm/comm.go
@@ -1224,13 +1224,10 @@ func (x *xArm) getLoad(ctx context.Context) ([]float64, error) {
 	return loads, nil
 }
 
-// ftSensorValueCount is the number of values the 6-axis F/T sensor returns:
-// Fx, Fy, Fz, Tx, Ty, Tz.
 const ftSensorValueCount = 6
 
-// parseFTSensorData parses the controller response for FTSensorData (0xC8).
-// params[0] is a leading status byte; the six float32 values follow, little-endian,
-// at offset i*4+1 (same layout as getLoad / JointPositions).
+// parseFTSensorData parses FTSensorData (0xC8): params[0] is a status byte, then six
+// little-endian float32 values at offset i*4+1.
 func parseFTSensorData(params []byte) ([]float64, error) {
 	need := 1 + ftSensorValueCount*4
 	if len(params) < need {
@@ -1244,7 +1241,6 @@ func parseFTSensorData(params []byte) ([]float64, error) {
 	return vals, nil
 }
 
-// getFTSensorData reads the wrist 6-axis F/T sensor: [Fx, Fy, Fz, Tx, Ty, Tz].
 func (x *xArm) getFTSensorData(ctx context.Context) ([]float64, error) {
 	c := x.newCmd(regMap["FTSensorData"])
 	resp, err := x.send(ctx, c, true)
@@ -1254,9 +1250,6 @@ func (x *xArm) getFTSensorData(ctx context.Context) ([]float64, error) {
 	return parseFTSensorData(resp.params)
 }
 
-// setFTSensorZero tares the sensor: the controller snapshots the current reading as
-// the offset subtracted from all subsequent reads. The arm should be stationary at
-// the reference pose/payload and the sensor must be enabled first.
 func (x *xArm) setFTSensorZero(ctx context.Context) error {
 	c := x.newCmd(regMap["FTSensorZero"])
 	_, err := x.send(ctx, c, true)

--- a/arm/comm.go
+++ b/arm/comm.go
@@ -49,7 +49,6 @@ var regMap = map[string]byte{
 	"EnableBound":    0x34,
 	"CurrentTorque":  0x37,
 	"FTSensorData":   0xC8,
-	"FTSensorEnable": 0xC9,
 	"FTSensorZero":   0xCE,
 	"SetEEModel":     0x4E,
 	"ServoError":     0x6A,
@@ -1253,18 +1252,6 @@ func (x *xArm) getFTSensorData(ctx context.Context) ([]float64, error) {
 		return nil, err
 	}
 	return parseFTSensorData(resp.params)
-}
-
-// setFTSensorEnable enables or disables the 6-axis F/T sensor.
-func (x *xArm) setFTSensorEnable(ctx context.Context, enable bool) error {
-	c := x.newCmd(regMap["FTSensorEnable"])
-	var b byte
-	if enable {
-		b = 0x01
-	}
-	c.params = append(c.params, b)
-	_, err := x.send(ctx, c, true)
-	return err
 }
 
 // setFTSensorZero tares the sensor: the controller snapshots the current reading as

--- a/arm/comm.go
+++ b/arm/comm.go
@@ -27,6 +27,7 @@ const manualMode = 2
 const errorState = 1 << 6
 const warningState = 1 << 5
 const notReadyForMotionState = 1 << 4
+const ftSensorValueCount = 6
 
 var regMap = map[string]byte{
 	"Version":        0x01,
@@ -1223,8 +1224,6 @@ func (x *xArm) getLoad(ctx context.Context) ([]float64, error) {
 
 	return loads, nil
 }
-
-const ftSensorValueCount = 6
 
 // parseFTSensorData parses FTSensorData (0xC8): params[0] is a status byte, then six
 // little-endian float32 values at offset i*4+1.

--- a/arm/comm_test.go
+++ b/arm/comm_test.go
@@ -1,12 +1,34 @@
 package arm
 
 import (
+	"encoding/binary"
+	"math"
 	"testing"
 
 	"go.viam.com/rdk/logging"
 	"go.viam.com/rdk/utils"
 	"go.viam.com/test"
 )
+
+func TestParseFTSensorData(t *testing.T) {
+	// Build a controller frame: 1 leading byte, then 6 little-endian float32 values.
+	want := []float64{-0.9871726, -2.9230627, -18.356257, -0.0012335, -0.0913722, 0.0069847}
+	params := make([]byte, 1+6*4)
+	for i, v := range want {
+		binary.LittleEndian.PutUint32(params[i*4+1:i*4+5], math.Float32bits(float32(v)))
+	}
+
+	got, err := parseFTSensorData(params)
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, len(got), test.ShouldEqual, 6)
+	for i := range want {
+		test.That(t, got[i], test.ShouldAlmostEqual, want[i], 1e-4)
+	}
+
+	// Too-short frame is an error, not a panic.
+	_, err = parseFTSensorData(make([]byte, 4))
+	test.That(t, err, test.ShouldNotBeNil)
+}
 
 func TestCreateRawJointSteps1(t *testing.T) {
 	var err error

--- a/arm/comm_test.go
+++ b/arm/comm_test.go
@@ -25,7 +25,6 @@ func TestParseFTSensorData(t *testing.T) {
 		test.That(t, got[i], test.ShouldAlmostEqual, want[i], 1e-4)
 	}
 
-	// Too-short frame is an error, not a panic.
 	_, err = parseFTSensorData(make([]byte, 4))
 	test.That(t, err, test.ShouldNotBeNil)
 }

--- a/arm/ft_sensor.go
+++ b/arm/ft_sensor.go
@@ -14,13 +14,12 @@ import (
 // FTSensorModel is the model for the ufactory wrist-mounted 6-axis Force/Torque sensor.
 var FTSensorModel = family.WithModel("ft_sensor")
 
-// FTSensorConfig is the config for the F/T sensor. It depends on an arm, which owns
-// the controller connection.
+// FTSensorConfig is the config for the F/T sensor.
 type FTSensorConfig struct {
 	Arm string `json:"arm"`
 }
 
-// Validate ensures the arm dependency is set and returns it as a required dependency.
+// Validate ensures the arm dependency is set.
 func (cfg *FTSensorConfig) Validate(path string) ([]string, []string, error) {
 	if cfg.Arm == "" {
 		return nil, nil, utils.NewConfigValidationFieldRequiredError(path, "arm")
@@ -61,7 +60,6 @@ func newFTSensor(ctx context.Context, deps resource.Dependencies, conf resource.
 	return s, nil
 }
 
-// Readings returns the latest F/T values using UR-compatible keys.
 func (s *ftSensor) Readings(ctx context.Context, extra map[string]any) (map[string]any, error) {
 	res, err := s.arm.DoCommand(ctx, map[string]any{getFTSensorDataKey: true})
 	if err != nil {
@@ -74,7 +72,6 @@ func (s *ftSensor) Readings(ctx context.Context, extra map[string]any) (map[stri
 	return data, nil
 }
 
-// DoCommand supports {"tare": true} to zero the sensor at its current reading.
 func (s *ftSensor) DoCommand(ctx context.Context, cmd map[string]any) (map[string]any, error) {
 	if _, ok := cmd["tare"]; ok {
 		return s.arm.DoCommand(ctx, map[string]any{ftSensorZeroKey: true})

--- a/arm/ft_sensor.go
+++ b/arm/ft_sensor.go
@@ -1,0 +1,109 @@
+package arm
+
+import (
+	"context"
+
+	"github.com/pkg/errors"
+	"go.viam.com/rdk/components/arm"
+	"go.viam.com/rdk/components/sensor"
+	"go.viam.com/rdk/logging"
+	"go.viam.com/rdk/resource"
+	"go.viam.com/utils"
+)
+
+// FTSensorModel is the model for the ufactory wrist-mounted 6-axis Force/Torque sensor.
+var FTSensorModel = family.WithModel("ft_sensor")
+
+// FTSensorConfig is the config for the F/T sensor. It depends on an arm, which owns
+// the controller connection.
+type FTSensorConfig struct {
+	Arm string `json:"arm"`
+	// EnableOnStart sends set_ft_sensor_enable=true once at construction. Default
+	// false so the controller's persisted enable state (e.g. set in UFactory Studio)
+	// stays authoritative; non-Studio users set this true so reads work without a
+	// manual DoCommand.
+	EnableOnStart bool `json:"enable_on_start,omitempty"`
+}
+
+// Validate ensures the arm dependency is set and returns it as a required dependency.
+func (cfg *FTSensorConfig) Validate(path string) ([]string, []string, error) {
+	if cfg.Arm == "" {
+		return nil, nil, utils.NewConfigValidationFieldRequiredError(path, "arm")
+	}
+	return []string{cfg.Arm}, nil, nil
+}
+
+func init() {
+	resource.RegisterComponent(
+		sensor.API,
+		FTSensorModel,
+		resource.Registration[sensor.Sensor, *FTSensorConfig]{
+			Constructor: newFTSensor,
+		})
+}
+
+type ftSensor struct {
+	resource.AlwaysRebuild
+
+	name   resource.Name
+	arm    arm.Arm
+	logger logging.Logger
+}
+
+func newFTSensor(ctx context.Context, deps resource.Dependencies, conf resource.Config, logger logging.Logger) (sensor.Sensor, error) {
+	newConf, err := resource.NativeConfig[*FTSensorConfig](conf)
+	if err != nil {
+		return nil, err
+	}
+	s := &ftSensor{
+		name:   conf.ResourceName(),
+		logger: logger,
+	}
+	s.arm, err = arm.FromProvider(deps, newConf.Arm)
+	if err != nil {
+		return nil, err
+	}
+	if newConf.EnableOnStart {
+		if _, err := s.arm.DoCommand(ctx, map[string]any{setFTSensorEnableKey: true}); err != nil {
+			return nil, errors.Wrap(err, "failed to enable F/T sensor on start")
+		}
+	}
+	return s, nil
+}
+
+// Readings returns the latest F/T values using UR-compatible keys.
+func (s *ftSensor) Readings(ctx context.Context, extra map[string]any) (map[string]any, error) {
+	res, err := s.arm.DoCommand(ctx, map[string]any{getFTSensorDataKey: true})
+	if err != nil {
+		return nil, err
+	}
+	data, ok := res[ftSensorDataKey].(map[string]any)
+	if !ok {
+		return nil, errors.Errorf("arm did not return %s map, got %v", ftSensorDataKey, res)
+	}
+	return data, nil
+}
+
+// DoCommand supports {"tare": true} to zero the sensor and {"enable": <bool>} to
+// enable/disable it.
+func (s *ftSensor) DoCommand(ctx context.Context, cmd map[string]any) (map[string]any, error) {
+	if _, ok := cmd["tare"]; ok {
+		return s.arm.DoCommand(ctx, map[string]any{ftSensorZeroKey: true})
+	}
+	if val, ok := cmd["enable"]; ok {
+		return s.arm.DoCommand(ctx, map[string]any{setFTSensorEnableKey: val})
+	}
+	return map[string]any{}, nil
+}
+
+func (s *ftSensor) Name() resource.Name {
+	return s.name
+}
+
+func (s *ftSensor) Close(ctx context.Context) error {
+	return nil
+}
+
+func (s *ftSensor) Status(_ context.Context) (map[string]any, error) {
+	return map[string]any{}, nil
+}

--- a/arm/ft_sensor.go
+++ b/arm/ft_sensor.go
@@ -14,6 +14,19 @@ import (
 // FTSensorModel is the model for the ufactory wrist-mounted 6-axis Force/Torque sensor.
 var FTSensorModel = family.WithModel("ft_sensor")
 
+const tareKey = "tare"
+
+func ftReadingsMap(vals []float64) map[string]any {
+	return map[string]any{
+		"Fx_N":   vals[0],
+		"Fy_N":   vals[1],
+		"Fz_N":   vals[2],
+		"TRx_Nm": vals[3],
+		"TRy_Nm": vals[4],
+		"TRz_Nm": vals[5],
+	}
+}
+
 // FTSensorConfig is the config for the F/T sensor.
 type FTSensorConfig struct {
 	Arm string `json:"arm"`
@@ -73,7 +86,7 @@ func (s *ftSensor) Readings(ctx context.Context, extra map[string]any) (map[stri
 }
 
 func (s *ftSensor) DoCommand(ctx context.Context, cmd map[string]any) (map[string]any, error) {
-	if _, ok := cmd["tare"]; ok {
+	if _, ok := cmd[tareKey]; ok {
 		return s.arm.DoCommand(ctx, map[string]any{ftSensorZeroKey: true})
 	}
 	return map[string]any{}, nil

--- a/arm/ft_sensor.go
+++ b/arm/ft_sensor.go
@@ -18,11 +18,6 @@ var FTSensorModel = family.WithModel("ft_sensor")
 // the controller connection.
 type FTSensorConfig struct {
 	Arm string `json:"arm"`
-	// EnableOnStart sends set_ft_sensor_enable=true once at construction. Default
-	// false so the controller's persisted enable state (e.g. set in UFactory Studio)
-	// stays authoritative; non-Studio users set this true so reads work without a
-	// manual DoCommand.
-	EnableOnStart bool `json:"enable_on_start,omitempty"`
 }
 
 // Validate ensures the arm dependency is set and returns it as a required dependency.
@@ -63,11 +58,6 @@ func newFTSensor(ctx context.Context, deps resource.Dependencies, conf resource.
 	if err != nil {
 		return nil, err
 	}
-	if newConf.EnableOnStart {
-		if _, err := s.arm.DoCommand(ctx, map[string]any{setFTSensorEnableKey: true}); err != nil {
-			return nil, errors.Wrap(err, "failed to enable F/T sensor on start")
-		}
-	}
 	return s, nil
 }
 
@@ -84,14 +74,10 @@ func (s *ftSensor) Readings(ctx context.Context, extra map[string]any) (map[stri
 	return data, nil
 }
 
-// DoCommand supports {"tare": true} to zero the sensor and {"enable": <bool>} to
-// enable/disable it.
+// DoCommand supports {"tare": true} to zero the sensor at its current reading.
 func (s *ftSensor) DoCommand(ctx context.Context, cmd map[string]any) (map[string]any, error) {
 	if _, ok := cmd["tare"]; ok {
 		return s.arm.DoCommand(ctx, map[string]any{ftSensorZeroKey: true})
-	}
-	if val, ok := cmd["enable"]; ok {
-		return s.arm.DoCommand(ctx, map[string]any{setFTSensorEnableKey: val})
 	}
 	return map[string]any{}, nil
 }

--- a/arm/ft_sensor_test.go
+++ b/arm/ft_sensor_test.go
@@ -8,8 +8,7 @@ import (
 	"go.viam.com/test"
 )
 
-// fakeArm embeds arm.Arm so only DoCommand is implemented; any other call panics,
-// which is fine because the sensor only uses DoCommand.
+// fakeArm embeds arm.Arm so only DoCommand needs implementing.
 type fakeArm struct {
 	arm.Arm
 	lastCmd map[string]any

--- a/arm/ft_sensor_test.go
+++ b/arm/ft_sensor_test.go
@@ -40,7 +40,7 @@ func TestFTSensorDoCommandTare(t *testing.T) {
 	fa := &fakeArm{resp: map[string]any{}}
 	s := &ftSensor{arm: fa}
 
-	_, err := s.DoCommand(context.Background(), map[string]any{"tare": true})
+	_, err := s.DoCommand(context.Background(), map[string]any{tareKey: true})
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, fa.lastCmd[ftSensorZeroKey], test.ShouldEqual, true)
 }

--- a/arm/ft_sensor_test.go
+++ b/arm/ft_sensor_test.go
@@ -1,0 +1,62 @@
+package arm
+
+import (
+	"context"
+	"testing"
+
+	"go.viam.com/rdk/components/arm"
+	"go.viam.com/test"
+)
+
+// fakeArm embeds arm.Arm so only DoCommand is implemented; any other call panics,
+// which is fine because the sensor only uses DoCommand.
+type fakeArm struct {
+	arm.Arm
+	lastCmd map[string]any
+	resp    map[string]any
+	err     error
+}
+
+func (f *fakeArm) DoCommand(_ context.Context, cmd map[string]any) (map[string]any, error) {
+	f.lastCmd = cmd
+	return f.resp, f.err
+}
+
+func TestFTSensorReadings(t *testing.T) {
+	fa := &fakeArm{resp: map[string]any{
+		ftSensorDataKey: map[string]any{
+			"Fx_N": -0.987, "Fy_N": -2.923, "Fz_N": -18.356,
+			"TRx_Nm": -0.0012, "TRy_Nm": -0.0914, "TRz_Nm": 0.00698,
+		},
+	}}
+	s := &ftSensor{arm: fa}
+
+	readings, err := s.Readings(context.Background(), nil)
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, readings["Fz_N"], test.ShouldEqual, -18.356)
+	test.That(t, fa.lastCmd[getFTSensorDataKey], test.ShouldEqual, true)
+}
+
+func TestFTSensorDoCommandTare(t *testing.T) {
+	fa := &fakeArm{resp: map[string]any{}}
+	s := &ftSensor{arm: fa}
+
+	_, err := s.DoCommand(context.Background(), map[string]any{"tare": true})
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, fa.lastCmd[ftSensorZeroKey], test.ShouldEqual, true)
+
+	_, err = s.DoCommand(context.Background(), map[string]any{"enable": true})
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, fa.lastCmd[setFTSensorEnableKey], test.ShouldEqual, true)
+}
+
+func TestFTSensorConfigValidate(t *testing.T) {
+	cfg := &FTSensorConfig{}
+	_, _, err := cfg.Validate("path")
+	test.That(t, err, test.ShouldNotBeNil)
+
+	cfg.Arm = "myarm"
+	deps, _, err := cfg.Validate("path")
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, deps, test.ShouldResemble, []string{"myarm"})
+}

--- a/arm/ft_sensor_test.go
+++ b/arm/ft_sensor_test.go
@@ -44,10 +44,6 @@ func TestFTSensorDoCommandTare(t *testing.T) {
 	_, err := s.DoCommand(context.Background(), map[string]any{"tare": true})
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, fa.lastCmd[ftSensorZeroKey], test.ShouldEqual, true)
-
-	_, err = s.DoCommand(context.Background(), map[string]any{"enable": true})
-	test.That(t, err, test.ShouldBeNil)
-	test.That(t, fa.lastCmd[setFTSensorEnableKey], test.ShouldEqual, true)
 }
 
 func TestFTSensorConfigValidate(t *testing.T) {

--- a/arm/xarm.go
+++ b/arm/xarm.go
@@ -61,6 +61,10 @@ const (
 	gripperSpeedKey          = "gripper_speed"
 	enterManualModeKey       = "enter_manual_mode"
 	exitManualModeKey        = "exit_manual_mode"
+	getFTSensorDataKey       = "get_ft_sensor_data"
+	setFTSensorEnableKey     = "set_ft_sensor_enable"
+	ftSensorZeroKey          = "ft_sensor_zero"
+	ftSensorDataKey          = "ft_sensor_data"
 
 	// gripperLiteActionKeys.
 	gripperLiteActionOpen     = "open"
@@ -674,6 +678,18 @@ func (x *xArm) Kinematics(ctx context.Context) (referenceframe.Model, error) {
 	return x.model, nil
 }
 
+// ftReadingsMap converts [Fx, Fy, Fz, Tx, Ty, Tz] into the UR-compatible reading map.
+func ftReadingsMap(vals []float64) map[string]any {
+	return map[string]any{
+		"Fx_N":   vals[0],
+		"Fy_N":   vals[1],
+		"Fz_N":   vals[2],
+		"TRx_Nm": vals[3],
+		"TRy_Nm": vals[4],
+		"TRz_Nm": vals[5],
+	}
+}
+
 func (x *xArm) DoCommand(ctx context.Context, cmd map[string]any) (map[string]any, error) {
 	resp := map[string]any{}
 	validCommand := false
@@ -842,6 +858,31 @@ func (x *xArm) DoCommand(ctx context.Context, cmd map[string]any) (map[string]an
 			return nil, err
 		}
 		resp["status"] = "exited manual mode"
+		validCommand = true
+	}
+
+	if _, ok := cmd[getFTSensorDataKey]; ok {
+		vals, err := x.getFTSensorData(ctx)
+		if err != nil {
+			return nil, err
+		}
+		resp[ftSensorDataKey] = ftReadingsMap(vals)
+		validCommand = true
+	}
+	if val, ok := cmd[setFTSensorEnableKey]; ok {
+		enable, ok := val.(bool)
+		if !ok {
+			return nil, fmt.Errorf("%s must be a bool, got %v (%T)", setFTSensorEnableKey, val, val)
+		}
+		if err := x.setFTSensorEnable(ctx, enable); err != nil {
+			return nil, err
+		}
+		validCommand = true
+	}
+	if _, ok := cmd[ftSensorZeroKey]; ok {
+		if err := x.setFTSensorZero(ctx); err != nil {
+			return nil, err
+		}
 		validCommand = true
 	}
 

--- a/arm/xarm.go
+++ b/arm/xarm.go
@@ -677,7 +677,6 @@ func (x *xArm) Kinematics(ctx context.Context) (referenceframe.Model, error) {
 	return x.model, nil
 }
 
-// ftReadingsMap converts [Fx, Fy, Fz, Tx, Ty, Tz] into the UR-compatible reading map.
 func ftReadingsMap(vals []float64) map[string]any {
 	return map[string]any{
 		"Fx_N":   vals[0],

--- a/arm/xarm.go
+++ b/arm/xarm.go
@@ -62,7 +62,6 @@ const (
 	enterManualModeKey       = "enter_manual_mode"
 	exitManualModeKey        = "exit_manual_mode"
 	getFTSensorDataKey       = "get_ft_sensor_data"
-	setFTSensorEnableKey     = "set_ft_sensor_enable"
 	ftSensorZeroKey          = "ft_sensor_zero"
 	ftSensorDataKey          = "ft_sensor_data"
 
@@ -867,16 +866,6 @@ func (x *xArm) DoCommand(ctx context.Context, cmd map[string]any) (map[string]an
 			return nil, err
 		}
 		resp[ftSensorDataKey] = ftReadingsMap(vals)
-		validCommand = true
-	}
-	if val, ok := cmd[setFTSensorEnableKey]; ok {
-		enable, ok := val.(bool)
-		if !ok {
-			return nil, fmt.Errorf("%s must be a bool, got %v (%T)", setFTSensorEnableKey, val, val)
-		}
-		if err := x.setFTSensorEnable(ctx, enable); err != nil {
-			return nil, err
-		}
 		validCommand = true
 	}
 	if _, ok := cmd[ftSensorZeroKey]; ok {

--- a/arm/xarm.go
+++ b/arm/xarm.go
@@ -677,17 +677,6 @@ func (x *xArm) Kinematics(ctx context.Context) (referenceframe.Model, error) {
 	return x.model, nil
 }
 
-func ftReadingsMap(vals []float64) map[string]any {
-	return map[string]any{
-		"Fx_N":   vals[0],
-		"Fy_N":   vals[1],
-		"Fz_N":   vals[2],
-		"TRx_Nm": vals[3],
-		"TRy_Nm": vals[4],
-		"TRz_Nm": vals[5],
-	}
-}
-
 func (x *xArm) DoCommand(ctx context.Context, cmd map[string]any) (map[string]any, error) {
 	resp := map[string]any{}
 	validCommand := false

--- a/arm/xarm_test.go
+++ b/arm/xarm_test.go
@@ -165,3 +165,15 @@ func TestMoveOptions(t *testing.T) {
 	test.That(t, mo.acceleration, test.ShouldEqual, base.acceleration)
 	test.That(t, mo.moveHZ, test.ShouldEqual, base.moveHZ)
 }
+
+func TestFTReadingsMap(t *testing.T) {
+	vals := []float64{-0.987, -2.923, -18.356, -0.0012, -0.0914, 0.00698}
+	m := ftReadingsMap(vals)
+	test.That(t, m["Fx_N"], test.ShouldEqual, -0.987)
+	test.That(t, m["Fy_N"], test.ShouldEqual, -2.923)
+	test.That(t, m["Fz_N"], test.ShouldEqual, -18.356)
+	test.That(t, m["TRx_Nm"], test.ShouldEqual, -0.0012)
+	test.That(t, m["TRy_Nm"], test.ShouldEqual, -0.0914)
+	test.That(t, m["TRz_Nm"], test.ShouldEqual, 0.00698)
+	test.That(t, len(m), test.ShouldEqual, 6)
+}

--- a/main.go
+++ b/main.go
@@ -5,6 +5,7 @@ import (
 	xarm "github.com/viam-modules/viam-ufactory-xarm/arm"
 	"go.viam.com/rdk/components/arm"
 	"go.viam.com/rdk/components/gripper"
+	"go.viam.com/rdk/components/sensor"
 	"go.viam.com/rdk/module"
 	"go.viam.com/rdk/resource"
 )
@@ -19,5 +20,6 @@ func main() {
 		resource.APIModel{API: gripper.API, Model: xarm.GripperModelLite},
 		resource.APIModel{API: gripper.API, Model: xarm.VacuumGripperModel},
 		resource.APIModel{API: gripper.API, Model: xarm.VacuumGripperModelLite},
+		resource.APIModel{API: sensor.API, Model: xarm.FTSensorModel},
 	)
 }

--- a/meta.json
+++ b/meta.json
@@ -52,6 +52,12 @@
       "model": "viam:ufactory:gripper_lite",
       "markdown_link": "README.md#gripper-lite",
       "short_description": "gripper lite component driver for two fingers gripper install on lite6"
+    },
+    {
+      "api": "rdk:component:sensor",
+      "model": "viam:ufactory:ft_sensor",
+      "markdown_link": "README.md#force-torque-sensor",
+      "short_description": "6-axis force/torque sensor driver for the ufactory wrist-mounted F/T sensor"
     }
   ],
   "build":{


### PR DESCRIPTION
## Summary

Adds a new `viam:ufactory:ft_sensor` sensor model that exposes the UFactory wrist-mounted 6-axis Force/Torque sensor as a Viam `sensor`. The resource depends on a configured xArm and reads through the arm's existing controller connection (mirroring the gripper/vacuum pattern) rather than opening a second socket to the controller. Readings use UR-compatible keys so consumers written against a Universal Robots F/T sensor work unchanged.

## Testing:
- Configured F/T sensor via ufactory studio
- Check readings on app.viam.com and compared to values in python SDK. Verified they both match
- Called tare and saw forces zeroed out. 
