### PR TITLE
Clamp nominalAccelSteps to >= 1 to prevent maxVel=0 at low speeds

### DIFF
--- a/arm/comm.go
+++ b/arm/comm.go
@@ -702,11 +702,11 @@ func (x *xArm) createRawJointSteps(
 		from = toInputs
 	}
 
-	nominalAccelSteps := int((mo.speed / mo.acceleration) * mo.moveHZ) // This many steps to accelerate, and the same to decelerate
-	if float64(nominalAccelSteps) > stepTotal*0.95 {
-		nominalAccelSteps = int(0.95 * math.Sqrt(displacementTotal/mo.acceleration) * mo.moveHZ)
+	nominalAccelSteps := (mo.speed / mo.acceleration) * mo.moveHZ // This many steps to accelerate, and the same to decelerate
+	if nominalAccelSteps > stepTotal*0.95 {
+		nominalAccelSteps = 0.95 * math.Sqrt(displacementTotal/mo.acceleration) * mo.moveHZ
 	}
-	maxVel := (float64(nominalAccelSteps) / mo.moveHZ) * mo.acceleration
+	maxVel := (nominalAccelSteps / mo.moveHZ) * mo.acceleration
 
 	inputStepsReversed := [][]referenceframe.Input{}
 	for i := len(inputSteps) - 1; i >= 0; i-- {
@@ -719,7 +719,7 @@ func (x *xArm) createRawJointSteps(
 		allInputSteps [][]referenceframe.Input,
 		stopVel float64,
 	) (int, [][]float64, error) {
-		currSpeed := accelStep
+		currSpeed := math.Min(accelStep, mo.speed)
 		steps := [][]float64{}
 		from = startInputs
 		lastInputs := startInputs

--- a/arm/comm_test.go
+++ b/arm/comm_test.go
@@ -52,3 +52,29 @@ func TestCreateRawJointSteps1(t *testing.T) {
 	test.That(t, len(out), test.ShouldBeGreaterThan, minMoves)
 	test.That(t, len(out), test.ShouldBeLessThan, 20+minMoves)
 }
+
+func TestCreateRawJointStepsLowSpeed(t *testing.T) {
+	var err error
+	logger := logging.NewTestLogger(t)
+
+	x := &xArm{
+		speed:        utils.DegToRad(3),
+		acceleration: utils.DegToRad(defaultAccel),
+		moveHZ:       defaultMoveHz,
+	}
+
+	start := []float64{0, 0, 0, 0, 0, 0}
+	x.model, err = MakeModelFrame(ModelName6DOF, nil, start, false, nil, logger)
+	test.That(t, err, test.ShouldBeNil)
+
+	displacement := 1.0
+	positions := [][]float64{{displacement, 0, 0, 0, 0, displacement}}
+
+	out, err := x.createRawJointSteps(start, positions, x.moveOptions(nil, nil))
+	test.That(t, err, test.ShouldBeNil)
+
+	expected := (displacement / x.speed) * x.moveHZ
+	// 15% band absorbs accel/decel ramp overhead.
+	test.That(t, float64(len(out)), test.ShouldBeGreaterThan, 0.85*expected)
+	test.That(t, float64(len(out)), test.ShouldBeLessThan, 1.15*expected)
+}


### PR DESCRIPTION
## Bug
setting `speed_degs_per_sec` below ~3.82 didn't slow the arm - it actually moved *faster* than the configured value. 3 --> fast, 4 --> slow. It moved the arm dangerously fast
 
## Cause
`createRawJointSteps` computed the accel-ramp step count as `int((speed/acceleration)*moveHZ)`. With default accel and moveHZ that expression is `speed / 3.82`, so any speed  below ~3.82 deg/s truncated to **0**, which zeroed `maxVel` and collapsed the velocity profile onto a fixed-velocity fallback path that ignored the configured speed

## Fix
keep `nominalAccelSteps` as a `float64` (no truncation), and cap the accel curve's initial `currSpeed` at `mo.speed` so slow speeds don't overshoot on the first iteration. Both changes are no-ops above the threshold

## Manual Testing
Manually tested on a ufactory arm