### PR TITLE
RSDK-14106: Use resource name as input to model parsing.

### DIFF
--- a/arm/comm_test.go
+++ b/arm/comm_test.go
@@ -19,7 +19,7 @@ func TestCreateRawJointSteps1(t *testing.T) {
 	}
 
 	start := []float64{0, 0, 0, 0, 0, 0}
-	x.model, err = MakeModelFrame(ModelName6DOF, nil, start, false, nil, logger)
+	x.model, err = MakeModelFrame("", ModelName6DOF, nil, start, false, nil, logger)
 	test.That(t, err, test.ShouldBeNil)
 
 	positions := [][]float64{{1, 0, 0, 0, 0, 1}}

--- a/arm/xarm.go
+++ b/arm/xarm.go
@@ -314,7 +314,7 @@ func getModelJSON(modelName string) ([]byte, error) {
 
 // MakeModelFrame returns the kinematics model of the xarm arm, which has all Frame information.
 func MakeModelFrame(
-	modelName string, badJoints []int, current []referenceframe.Input, useURDFs bool, meshDecimationRatios []float64, logger logging.Logger,
+	resourceName string, modelName string, badJoints []int, current []referenceframe.Input, useURDFs bool, meshDecimationRatios []float64, logger logging.Logger,
 ) (referenceframe.Model, error) {
 	var cfg *referenceframe.ModelConfigJSON
 	if useURDFs {
@@ -344,7 +344,7 @@ func MakeModelFrame(
 		logger.Infof("locking joint %d to %v", j, now)
 	}
 
-	return cfg.ParseConfig(modelName)
+	return cfg.ParseConfig(resourceName)
 }
 
 func makeModelFrameFromURDF(modelName string, meshDecimationRatios []float64) (referenceframe.Model, error) {
@@ -447,7 +447,7 @@ func NewXArm(ctx context.Context, name resource.Name,
 		}
 	}
 
-	x.model, err = MakeModelFrame(modelName, newConf.BadJoints, current, newConf.UseURDFs, newConf.MeshDecimationRatios, logger)
+	x.model, err = MakeModelFrame(name.Name, modelName, newConf.BadJoints, current, newConf.UseURDFs, newConf.MeshDecimationRatios, logger)
 	if err != nil {
 		return nil, err
 	}

--- a/arm/xarm.go
+++ b/arm/xarm.go
@@ -314,7 +314,13 @@ func getModelJSON(modelName string) ([]byte, error) {
 
 // MakeModelFrame returns the kinematics model of the xarm arm, which has all Frame information.
 func MakeModelFrame(
-	resourceName string, modelName string, badJoints []int, current []referenceframe.Input, useURDFs bool, meshDecimationRatios []float64, logger logging.Logger,
+	resourceName string,
+	modelName string,
+	badJoints []int,
+	current []referenceframe.Input,
+	useURDFs bool,
+	meshDecimationRatios []float64,
+	logger logging.Logger,
 ) (referenceframe.Model, error) {
 	var cfg *referenceframe.ModelConfigJSON
 	if useURDFs {

--- a/arm/xarm_test.go
+++ b/arm/xarm_test.go
@@ -35,7 +35,7 @@ func TestMakeModelFrameJSON(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			m, err := MakeModelFrame(tc.model, nil, nil, false, nil, logger)
+			m, err := MakeModelFrame("", tc.model, nil, nil, false, nil, logger)
 			test.That(t, err, test.ShouldBeNil)
 			test.That(t, m, test.ShouldNotBeNil)
 			test.That(t, len(m.DoF()), test.ShouldEqual, tc.expected)
@@ -63,7 +63,7 @@ func TestMakeModelFrameURDF(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			m, err := MakeModelFrame(tc.model, nil, nil, true, nil, logger)
+			m, err := MakeModelFrame("", tc.model, nil, nil, true, nil, logger)
 			test.That(t, err, test.ShouldBeNil)
 			test.That(t, m, test.ShouldNotBeNil)
 			test.That(t, len(m.DoF()), test.ShouldEqual, tc.expected)
@@ -77,14 +77,14 @@ func TestMakeModelFrameURDFMissingEnv(t *testing.T) {
 	// Ensure VIAM_MODULE_ROOT points to a nonexistent directory.
 	t.Setenv("VIAM_MODULE_ROOT", "/nonexistent/path")
 
-	_, err := MakeModelFrame(ModelName6DOF, nil, nil, true, nil, logger)
+	_, err := MakeModelFrame("", ModelName6DOF, nil, nil, true, nil, logger)
 	test.That(t, err, test.ShouldNotBeNil)
 }
 
 func TestMakeModelFrameURDFUnknownModel(t *testing.T) {
 	logger := logging.NewTestLogger(t)
 
-	_, err := MakeModelFrame("unknownModel", nil, nil, true, nil, logger)
+	_, err := MakeModelFrame("", "unknownModel", nil, nil, true, nil, logger)
 	test.That(t, err, test.ShouldNotBeNil)
 	test.That(t, err.Error(), test.ShouldContainSubstring, "no URDF file for xarm model")
 }
@@ -98,7 +98,7 @@ func TestMakeModelFrameWithBadJoints(t *testing.T) {
 		current[i] = 0
 	}
 
-	m, err := MakeModelFrame(ModelName6DOF, []int{2}, current, false, nil, logger)
+	m, err := MakeModelFrame("", ModelName6DOF, []int{2}, current, false, nil, logger)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, m, test.ShouldNotBeNil)
 	test.That(t, len(m.DoF()), test.ShouldEqual, 6)

--- a/mptests/mp_perf_test.go
+++ b/mptests/mp_perf_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func makeTestFrameSystem(logger logging.Logger) (*referenceframe.FrameSystem, error) {
-	armModel, err := xarm.MakeModelFrame(xarm.ModelName6DOF, nil, nil, false, nil, logger)
+	armModel, err := xarm.MakeModelFrame("", xarm.ModelName6DOF, nil, nil, false, nil, logger)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This is reflected in geometry names and hence important for visualization parenting.

This was tested with a hot reload on vino2. Screenshots showing before/afters on the ticket.

To be clear, the arm models/kinematics shouldn't need to know about resource names, but that's what we have today to get the geometry labels to line up with frame names such that the visualizer can work.

@npmenard, Can you make sure all the other relevant arms are brought up to this state?