### PR TITLE
Run PR CI on pull_request instead of pull_request_target

### DIFF
--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -5,7 +5,8 @@ concurrency:
   cancel-in-progress: true
 
 on:
-  pull_request_target:
+  # plain pull_request: fork runs get no secrets and a read-only token
+  pull_request:
     branches: [ 'main' ]
     
 jobs:


### PR DESCRIPTION
pullrequest.yml ran fork PRs under `pull_request_target`, which executes untrusted PR code with repo secrets available and a privileged `GITHUB_TOKEN` persisted by checkout. The PR jobs here (test, license finder) reference no secrets, so plain `pull_request` does the same work while GitHub withholds secrets and issues a read-only token for fork runs. The `event_name` checks in the reusable workflows already handle this: on `pull_request` the default checkout picks the PR merge ref.

Part of an org-wide sweep of `pull_request_target` use (same change as viamrobotics/viam-python-sdk#1246).

🤖 Generated with [Claude Code](https://claude.com/claude-code)