### PR TITLE
Report no gripper kinematics when use_urdfs is unset

### DIFF
--- a/arm/gripper.go
+++ b/arm/gripper.go
@@ -114,14 +114,14 @@ func newGripperLite(ctx context.Context, deps resource.Dependencies, config reso
 		return nil, err
 	}
 
+	// mf stays nil unless use_urdfs is set; see Kinematics for why the non-URDF
+	// path must not hand back a model.
 	var mf referenceframe.Model
 	if newConf.UseURDFs {
 		mf, err = loadGripperModel(ModelNameGripperLite, newConf.MeshDecimationRatio, logger)
 		if err != nil {
 			return nil, fmt.Errorf("gripper_lite kinematics: %w", err)
 		}
-	} else {
-		mf = referenceframe.NewSimpleModel(ModelNameGripperLite)
 	}
 
 	g := &myGripperLite{
@@ -229,7 +229,7 @@ func (g *myGripperLite) Geometries(ctx context.Context, _ map[string]any) ([]spa
 }
 
 func (g *myGripperLite) Kinematics(ctx context.Context) (referenceframe.Model, error) {
-	return g.mf, nil
+	return gripperKinematics(g.mf)
 }
 
 func (g *myGripperLite) CurrentInputs(ctx context.Context) ([]referenceframe.Input, error) {
@@ -267,14 +267,14 @@ func newGripper(ctx context.Context, deps resource.Dependencies, config resource
 		return nil, err
 	}
 
+	// mf stays nil unless use_urdfs is set; see Kinematics for why the non-URDF
+	// path must not hand back a model.
 	var mf referenceframe.Model
 	if newConf.UseURDFs {
 		mf, err = loadGripperModel(ModelNameGripper, newConf.MeshDecimationRatio, logger)
 		if err != nil {
 			return nil, fmt.Errorf("gripper kinematics: %w", err)
 		}
-	} else {
-		mf = referenceframe.NewSimpleModel(ModelNameGripper)
 	}
 
 	g := &myGripper{
@@ -466,7 +466,7 @@ func (g *myGripper) Geometries(ctx context.Context, _ map[string]any) ([]spatial
 }
 
 func (g *myGripper) Kinematics(ctx context.Context) (referenceframe.Model, error) {
-	return g.mf, nil
+	return gripperKinematics(g.mf)
 }
 
 func (g *myGripper) CurrentInputs(ctx context.Context) ([]referenceframe.Input, error) {

--- a/arm/kinematics.go
+++ b/arm/kinematics.go
@@ -1,6 +1,7 @@
 package arm
 
 import (
+	"errors"
 	"fmt"
 
 	"go.viam.com/rdk/logging"
@@ -65,6 +66,22 @@ func resolveGripperKinematicsArtifact(modelName string) (kinematicsArtifact, err
 		return base, nil
 	}
 	return kinematicsArtifact{}, fmt.Errorf("no kinematics artifact for gripper model %s", modelName)
+}
+
+// gripperKinematics reports a gripper's model to the frame system.
+//
+// A nil mf (use_urdfs unset) MUST surface as an error rather than an empty
+// model. RDK's gripper client only falls back to Geometries() + MakeModel —
+// the sole route by which the hand-authored bounding boxes reach the frame
+// system — when GetKinematics fails. An empty model succeeds instead: it has no
+// ModelConfig, so KinematicModelToProtobuf ships FORMAT_UNSPECIFIED with no
+// data, the client caches a geometry-less model, and the gripper lands in the
+// frame system with nothing to collide against.
+func gripperKinematics(mf referenceframe.Model) (referenceframe.Model, error) {
+	if mf == nil {
+		return nil, errors.ErrUnsupported
+	}
+	return mf, nil
 }
 
 const gripperDefaultMeshDecimationRatio = 0.1

--- a/arm/kinematics_test.go
+++ b/arm/kinematics_test.go
@@ -1,0 +1,82 @@
+package arm
+
+import (
+	"context"
+	"testing"
+
+	commonpb "go.viam.com/api/common/v1"
+	"go.viam.com/rdk/referenceframe"
+	"go.viam.com/rdk/spatialmath"
+	"go.viam.com/test"
+)
+
+func TestGripperKinematics(t *testing.T) {
+	_, err := gripperKinematics(nil)
+	test.That(t, err, test.ShouldNotBeNil)
+
+	loaded, err := referenceframe.UnmarshalModelJSON(xArm6modeljson, ModelName6DOF)
+	test.That(t, err, test.ShouldBeNil)
+	got, err := gripperKinematics(loaded)
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, got, test.ShouldEqual, loaded)
+}
+
+// An empty SimpleModel has no ModelConfig, so GetKinematics ships it with no
+// kinematics data and the client rebuilds an equally empty model rather than
+// falling back to Geometries(). Guards the reason Kinematics must error when it
+// has no model to report.
+func TestEmptyModelDoesNotSurviveGetKinematics(t *testing.T) {
+	resp := referenceframe.KinematicModelToProtobuf(referenceframe.NewSimpleModel(ModelNameGripper))
+	test.That(t, resp.GetKinematicsData(), test.ShouldBeEmpty)
+	test.That(t, resp.GetFormat(), test.ShouldEqual, commonpb.KinematicsFileFormat_KINEMATICS_FILE_FORMAT_UNSPECIFIED)
+
+	rebuilt, err := referenceframe.KinematicModelFromProtobuf(ModelNameGripper, resp)
+	test.That(t, err, test.ShouldBeNil)
+	gif, err := rebuilt.Geometries(nil)
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, gif.Geometries(), test.ShouldBeEmpty)
+}
+
+// Without use_urdfs every gripper must report no kinematics and non-empty
+// geometries, which is what drives RDK's client onto the Geometries() fallback
+// that puts the hand-authored boxes into the frame system.
+func TestGrippersReportBoxesWhenURDFsDisabled(t *testing.T) {
+	ctx := context.Background()
+
+	type kinematicGripper interface {
+		Kinematics(ctx context.Context) (referenceframe.Model, error)
+		Geometries(ctx context.Context, extra map[string]any) ([]spatialmath.Geometry, error)
+	}
+
+	for _, tc := range []struct {
+		name   string
+		g      kinematicGripper
+		labels []string
+	}{
+		{"gripper", &myGripper{}, []string{"case-gripper", "claws"}},
+		{"gripper_lite", &myGripperLite{}, []string{"case-gripper", "claws"}},
+		{
+			"vacuum_gripper",
+			&myVacuumGripper{model: VacuumGripperModel, conf: &GripperConfig{}},
+			[]string{"vacuum-gripper-box", "vacuum-gripper-tube"},
+		},
+		{
+			"vacuum_gripper_lite",
+			&myVacuumGripper{model: VacuumGripperModelLite, conf: &GripperConfig{}},
+			[]string{"vacuum-gripper-box", "vacuum-gripper-tube"},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := tc.g.Kinematics(ctx)
+			test.That(t, err, test.ShouldNotBeNil)
+
+			geoms, err := tc.g.Geometries(ctx, nil)
+			test.That(t, err, test.ShouldBeNil)
+			labels := make([]string, len(geoms))
+			for i, geom := range geoms {
+				labels[i] = geom.Label()
+			}
+			test.That(t, labels, test.ShouldResemble, tc.labels)
+		})
+	}
+}

--- a/arm/vacuum_gripper.go
+++ b/arm/vacuum_gripper.go
@@ -89,14 +89,14 @@ func newVacuumGripper(ctx context.Context, deps resource.Dependencies, config re
 		return nil, err
 	}
 
+	// mf stays nil unless use_urdfs is set; see Kinematics for why the non-URDF
+	// path must not hand back a model.
 	var mf referenceframe.Model
 	if newConf.UseURDFs {
 		mf, err = loadGripperModel(config.Model.Name, newConf.MeshDecimationRatio, logger)
 		if err != nil {
 			return nil, fmt.Errorf("%s kinematics: %w", config.Model.Name, err)
 		}
-	} else {
-		mf = referenceframe.NewSimpleModel(config.Model.Name)
 	}
 
 	g := &myVacuumGripper{
@@ -269,7 +269,7 @@ func vacuumGripperGeometries(model resource.Model, vacuumLengthMM float64) ([]sp
 }
 
 func (g *myVacuumGripper) Kinematics(ctx context.Context) (referenceframe.Model, error) {
-	return g.mf, nil
+	return gripperKinematics(g.mf)
 }
 
 func (g *myVacuumGripper) CurrentInputs(ctx context.Context) ([]referenceframe.Input, error) {


### PR DESCRIPTION
## Summary

Since #81 grippers plan with no collision geometry. `Kinematics` returns an empty `SimpleModel` rather than an error; that model has no `ModelConfig`, so `KinematicModelToProtobuf` ships `FORMAT_UNSPECIFIED` with no data and RDK's gripper client rebuilds an equally empty model instead of falling back to `Geometries` + `MakeModel` — the only route by which the hand-authored bounding boxes reached the frame system.

Leaving the model nil unless `use_urdfs` is set and reporting that as an error puts the client back on the fallback, restoring the pre-#81 frame system.

Affects all four gripper models whenever `use_urdfs` is unset, which is the default.

> Alternative to #100, which fixes the same bug by making the model itself wire-survivable. Pick one. This is the smaller diff but leans on a fallback RDK's own comment calls "the old method".

## Changes

- **arm/kinematics.go**: add `gripperKinematics`, erroring on a nil model so the client takes the geometry fallback
- **arm/gripper.go**, **arm/vacuum_gripper.go**: build a model only when `use_urdfs` is set

## Testing

- `arm/kinematics_test.go` pins the mechanism: an empty `SimpleModel` loses its geometry crossing `GetKinematics`, and each gripper reports no kinematics but non-empty boxes when `use_urdfs` is off.

<details>
<summary>Claude Code prompts used</summary>

- "Hi Claude, I think a regression or a breaking change was introduced in https://github.com/viam-modules/viam-ufactory-xarm/pull/81. when I upgraded Cappuccina to this version I ran into an issue where the gripper geometries were absent from the framesystem during the planning. The plan request of interest is at @../rdk/mplans/cappuccina_failed_lock.json . Can you look into it and tell me where the issue is?"
- "Can you spin up 2 worktrees and implement one in each?"
- "create a draft PR for each"

</details>