### PR TITLE
Build gripper box models that survive GetKinematics

### DIFF
--- a/arm/gripper.go
+++ b/arm/gripper.go
@@ -114,14 +114,9 @@ func newGripperLite(ctx context.Context, deps resource.Dependencies, config reso
 		return nil, err
 	}
 
-	var mf referenceframe.Model
-	if newConf.UseURDFs {
-		mf, err = loadGripperModel(ModelNameGripperLite, newConf.MeshDecimationRatio, logger)
-		if err != nil {
-			return nil, fmt.Errorf("gripper_lite kinematics: %w", err)
-		}
-	} else {
-		mf = referenceframe.NewSimpleModel(ModelNameGripperLite)
+	mf, err := newGripperKinematics(ModelNameGripperLite, newConf, logger, liteGripperGeometries)
+	if err != nil {
+		return nil, fmt.Errorf("gripper_lite kinematics: %w", err)
 	}
 
 	g := &myGripperLite{
@@ -267,14 +262,9 @@ func newGripper(ctx context.Context, deps resource.Dependencies, config resource
 		return nil, err
 	}
 
-	var mf referenceframe.Model
-	if newConf.UseURDFs {
-		mf, err = loadGripperModel(ModelNameGripper, newConf.MeshDecimationRatio, logger)
-		if err != nil {
-			return nil, fmt.Errorf("gripper kinematics: %w", err)
-		}
-	} else {
-		mf = referenceframe.NewSimpleModel(ModelNameGripper)
+	mf, err := newGripperKinematics(ModelNameGripper, newConf, logger, standardGripperGeometries)
+	if err != nil {
+		return nil, fmt.Errorf("gripper kinematics: %w", err)
 	}
 
 	g := &myGripper{

--- a/arm/kinematics.go
+++ b/arm/kinematics.go
@@ -1,10 +1,12 @@
 package arm
 
 import (
+	"encoding/json"
 	"fmt"
 
 	"go.viam.com/rdk/logging"
 	"go.viam.com/rdk/referenceframe"
+	"go.viam.com/rdk/spatialmath"
 )
 
 // kinematicsArtifact identifies the kinematics files to use for an
@@ -65,6 +67,64 @@ func resolveGripperKinematicsArtifact(modelName string) (kinematicsArtifact, err
 		return base, nil
 	}
 	return kinematicsArtifact{}, fmt.Errorf("no kinematics artifact for gripper model %s", modelName)
+}
+
+// makeGeometryModel builds a zero-DoF kinematics model whose links carry geoms.
+// Each geometry gets its own link, chained parent-to-child, because a link
+// config holds at most one geometry.
+//
+// The config is marshalled into OriginalFile before being parsed. RDK forwards a
+// model over GetKinematics only when ModelConfig().OriginalFile is set (see
+// referenceframe.KinematicModelToProtobuf); without it the response carries no
+// kinematics data, the caller reconstructs an empty model, and the gripper lands
+// in the frame system with nothing to collide against.
+func makeGeometryModel(name string, geoms []spatialmath.Geometry) (referenceframe.Model, error) {
+	if len(geoms) == 0 {
+		return nil, fmt.Errorf("no geometries to build a kinematics model for %s", name)
+	}
+
+	cfg := &referenceframe.ModelConfigJSON{Name: name}
+	parent := referenceframe.World
+	for _, geom := range geoms {
+		frame, err := referenceframe.NewStaticFrameWithGeometry(geom.Label(), spatialmath.NewZeroPose(), geom)
+		if err != nil {
+			return nil, err
+		}
+		link, err := referenceframe.NewLinkConfig(frame)
+		if err != nil {
+			return nil, err
+		}
+		link.Parent = parent
+		parent = geom.Label()
+		cfg.Links = append(cfg.Links, *link)
+	}
+
+	raw, err := json.Marshal(cfg)
+	if err != nil {
+		return nil, err
+	}
+	cfg.OriginalFile = &referenceframe.ModelFile{Bytes: raw, Extension: "json"}
+
+	return cfg.ParseConfig(name)
+}
+
+// newGripperKinematics builds the model a gripper reports to the frame system:
+// URDF-derived meshes when use_urdfs is set, otherwise a model carrying the
+// hand-authored bounding boxes that boxGeoms produces.
+func newGripperKinematics(
+	modelName string,
+	conf *GripperConfig,
+	logger logging.Logger,
+	boxGeoms func() ([]spatialmath.Geometry, error),
+) (referenceframe.Model, error) {
+	if conf.UseURDFs {
+		return loadGripperModel(modelName, conf.MeshDecimationRatio, logger)
+	}
+	geoms, err := boxGeoms()
+	if err != nil {
+		return nil, err
+	}
+	return makeGeometryModel(modelName, geoms)
 }
 
 const gripperDefaultMeshDecimationRatio = 0.1

--- a/arm/kinematics_test.go
+++ b/arm/kinematics_test.go
@@ -1,0 +1,97 @@
+package arm
+
+import (
+	"testing"
+
+	"github.com/golang/geo/r3"
+	"go.viam.com/rdk/logging"
+	"go.viam.com/rdk/referenceframe"
+	"go.viam.com/rdk/spatialmath"
+	"go.viam.com/test"
+)
+
+func TestMakeGeometryModelRequiresGeometries(t *testing.T) {
+	_, err := makeGeometryModel(ModelNameGripper, nil)
+	test.That(t, err, test.ShouldNotBeNil)
+}
+
+// The model must carry an OriginalFile, otherwise KinematicModelToProtobuf drops
+// it and the gripper reaches the frame system with no collision geometry.
+func TestMakeGeometryModelSurvivesGetKinematics(t *testing.T) {
+	box, err := spatialmath.NewBox(
+		spatialmath.NewPoseFromPoint(r3.Vector{X: 0, Y: 0, Z: -50}),
+		r3.Vector{X: 50, Y: 100, Z: 100}, "case-gripper")
+	test.That(t, err, test.ShouldBeNil)
+
+	mf, err := makeGeometryModel(ModelNameGripper, []spatialmath.Geometry{box})
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, mf.ModelConfig().OriginalFile, test.ShouldNotBeNil)
+	test.That(t, mf.ModelConfig().OriginalFile.Extension, test.ShouldEqual, "json")
+
+	resp := referenceframe.KinematicModelToProtobuf(mf)
+	test.That(t, resp.GetKinematicsData(), test.ShouldNotBeEmpty)
+
+	rebuilt, err := referenceframe.KinematicModelFromProtobuf(ModelNameGripper, resp)
+	test.That(t, err, test.ShouldBeNil)
+	rebuiltGeoms := modelGeometries(t, rebuilt)
+	test.That(t, rebuiltGeoms, test.ShouldHaveLength, 1)
+	test.That(t, spatialmath.GeometriesAlmostEqual(rebuiltGeoms[0], box), test.ShouldBeTrue)
+}
+
+// Each gripper's default (non-URDF) model must reach a planner with the same
+// bounding boxes its Geometries method reports.
+func TestGripperModelsCarryBoxesThroughGetKinematics(t *testing.T) {
+	logger := logging.NewTestLogger(t)
+
+	for _, tc := range []struct {
+		name  string
+		geoms func() ([]spatialmath.Geometry, error)
+	}{
+		{ModelNameGripper, standardGripperGeometries},
+		{ModelNameGripperLite, liteGripperGeometries},
+		{
+			ModelNameVacuumGripper,
+			func() ([]spatialmath.Geometry, error) { return vacuumGripperGeometries(VacuumGripperModel, 30) },
+		},
+		{
+			ModelNameVacuumGripperLite,
+			func() ([]spatialmath.Geometry, error) { return vacuumGripperGeometries(VacuumGripperModelLite, 0) },
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			want, err := tc.geoms()
+			test.That(t, err, test.ShouldBeNil)
+			test.That(t, want, test.ShouldNotBeEmpty)
+
+			mf, err := newGripperKinematics(tc.name, &GripperConfig{}, logger, tc.geoms)
+			test.That(t, err, test.ShouldBeNil)
+
+			// Round-trip the way the module server and its caller do.
+			rebuilt, err := referenceframe.KinematicModelFromProtobuf(tc.name, referenceframe.KinematicModelToProtobuf(mf))
+			test.That(t, err, test.ShouldBeNil)
+
+			got := modelGeometries(t, rebuilt)
+			test.That(t, got, test.ShouldHaveLength, len(want))
+			for i := range want {
+				// A model namespaces its geometry labels, as "arm:base_top" is.
+				test.That(t, got[i].Label(), test.ShouldEqual, tc.name+":"+want[i].Label())
+				test.That(t, spatialmath.GeometriesAlmostEqual(got[i], want[i]), test.ShouldBeTrue)
+			}
+
+			// Nothing is lost crossing the wire.
+			before := modelGeometries(t, mf)
+			test.That(t, before, test.ShouldHaveLength, len(got))
+			for i := range before {
+				test.That(t, got[i].Label(), test.ShouldEqual, before[i].Label())
+				test.That(t, spatialmath.GeometriesAlmostEqual(got[i], before[i]), test.ShouldBeTrue)
+			}
+		})
+	}
+}
+
+func modelGeometries(t *testing.T, mf referenceframe.Model) []spatialmath.Geometry {
+	t.Helper()
+	gif, err := mf.Geometries(make([]referenceframe.Input, len(mf.DoF())))
+	test.That(t, err, test.ShouldBeNil)
+	return gif.Geometries()
+}

--- a/arm/vacuum_gripper.go
+++ b/arm/vacuum_gripper.go
@@ -89,14 +89,11 @@ func newVacuumGripper(ctx context.Context, deps resource.Dependencies, config re
 		return nil, err
 	}
 
-	var mf referenceframe.Model
-	if newConf.UseURDFs {
-		mf, err = loadGripperModel(config.Model.Name, newConf.MeshDecimationRatio, logger)
-		if err != nil {
-			return nil, fmt.Errorf("%s kinematics: %w", config.Model.Name, err)
-		}
-	} else {
-		mf = referenceframe.NewSimpleModel(config.Model.Name)
+	mf, err := newGripperKinematics(config.Model.Name, newConf, logger, func() ([]spatialmath.Geometry, error) {
+		return vacuumGripperGeometries(config.Model, newConf.VacuumLengthMM)
+	})
+	if err != nil {
+		return nil, fmt.Errorf("%s kinematics: %w", config.Model.Name, err)
 	}
 
 	g := &myVacuumGripper{


### PR DESCRIPTION
## Summary

Since #81 grippers plan with no collision geometry. When `use_urdfs` is unset — the default — `Kinematics` returns an empty `SimpleModel`; that model has no `ModelConfig`, so `KinematicModelToProtobuf` ships `FORMAT_UNSPECIFIED` with no data, RDK's gripper client rebuilds an equally empty model, and the gripper reaches the frame system with nothing to collide against.

Build a real zero-DoF model from the hand-authored bounding boxes and attach the marshalled config as `OriginalFile`, which is what lets a model cross the wire at all. Deriving it from the existing geometry functions keeps one source of truth for the box dimensions and picks up the vacuum gripper's configurable suction-tube length, which a static kinematics file could not express.

> Alternative to #99, which fixes the same bug by restoring the error so RDK's client falls back to `Geometries`. Pick one.

## Changes

- **arm/kinematics.go**: add `makeGeometryModel` (one static link per geometry, config attached as `OriginalFile`) and `newGripperKinematics` to pick URDF meshes or boxes
- **arm/gripper.go**, **arm/vacuum_gripper.go**: route all three constructors through `newGripperKinematics`

## Testing

- `arm/kinematics_test.go` round-trips each gripper's model through `KinematicModelToProtobuf`/`FromProtobuf` and compares geometries against the hand-authored boxes.
- Verified against a known-good pre-#81 plan dump: the frame system comes back as `gripper` / `gripper:case-gripper` / `gripper:claws`, matching it exactly.

## Known gap (pre-existing, not addressed)

Under `use_urdfs: true` the vacuum gripper's suction tube is appended in `Geometries` only, so the frame system still plans without it. Fixing that needs URDF mesh geometry routed through `makeGeometryModel`, which depends on meshes round-tripping through `spatial.NewGeometryConfig` — unverified.

<details>
<summary>Claude Code prompts used</summary>

- "Hi Claude, I think a regression or a breaking change was introduced in https://github.com/viam-modules/viam-ufactory-xarm/pull/81. when I upgraded Cappuccina to this version I ran into an issue where the gripper geometries were absent from the framesystem during the planning. The plan request of interest is at @../rdk/mplans/cappuccina_failed_lock.json . Can you look into it and tell me where the issue is?"
- "Can you spin up 2 worktrees and implement one in each?"
- "create a draft PR for each"

</details>