### PR TITLE
gripper: expose open/closed state as 1-DoF CurrentInputs

### DIFF
--- a/arm/gripper.go
+++ b/arm/gripper.go
@@ -36,6 +36,11 @@ var (
 const fullyClosedThreshold = 10
 const fullyOpenThreshold = 830
 
+const (
+	gripperClosedInput = 0.0
+	gripperOpenInput   = 1.0
+)
+
 // GripperConfig config for gripper.
 type GripperConfig struct {
 	Arm            string
@@ -114,7 +119,7 @@ func newGripperLite(ctx context.Context, deps resource.Dependencies, config reso
 		return nil, err
 	}
 
-	mf, err := newGripperKinematics(ModelNameGripperLite, newConf, logger, liteGripperGeometries)
+	mf, err := newGripperKinematics(ModelNameGripperLite, newConf, logger, liteGripperGeometries, true)
 	if err != nil {
 		return nil, fmt.Errorf("gripper_lite kinematics: %w", err)
 	}
@@ -228,7 +233,18 @@ func (g *myGripperLite) Kinematics(ctx context.Context) (referenceframe.Model, e
 }
 
 func (g *myGripperLite) CurrentInputs(ctx context.Context) ([]referenceframe.Input, error) {
-	return nil, errors.ErrUnsupported
+	if len(g.mf.DoF()) == 0 {
+		return []referenceframe.Input{}, nil
+	}
+	status, err := g.IsHoldingSomething(ctx, nil)
+	if err != nil {
+		return nil, err
+	}
+	v := gripperOpenInput
+	if status.IsHoldingSomething {
+		v = gripperClosedInput
+	}
+	return []referenceframe.Input{v}, nil
 }
 
 func (g *myGripperLite) GoToInputs(ctx context.Context, inputs ...[]referenceframe.Input) error {
@@ -262,7 +278,7 @@ func newGripper(ctx context.Context, deps resource.Dependencies, config resource
 		return nil, err
 	}
 
-	mf, err := newGripperKinematics(ModelNameGripper, newConf, logger, standardGripperGeometries)
+	mf, err := newGripperKinematics(ModelNameGripper, newConf, logger, standardGripperGeometries, true)
 	if err != nil {
 		return nil, fmt.Errorf("gripper kinematics: %w", err)
 	}
@@ -460,7 +476,18 @@ func (g *myGripper) Kinematics(ctx context.Context) (referenceframe.Model, error
 }
 
 func (g *myGripper) CurrentInputs(ctx context.Context) ([]referenceframe.Input, error) {
-	return nil, errors.ErrUnsupported
+	if len(g.mf.DoF()) == 0 {
+		return []referenceframe.Input{}, nil
+	}
+	pos, err := g.getPosition(ctx)
+	if err != nil {
+		return nil, err
+	}
+	v := gripperClosedInput
+	if pos > (fullyClosedThreshold+fullyOpenThreshold)/2 {
+		v = gripperOpenInput
+	}
+	return []referenceframe.Input{v}, nil
 }
 
 func (g *myGripper) GoToInputs(ctx context.Context, inputs ...[]referenceframe.Input) error {

--- a/arm/kinematics.go
+++ b/arm/kinematics.go
@@ -69,7 +69,9 @@ func resolveGripperKinematicsArtifact(modelName string) (kinematicsArtifact, err
 	return kinematicsArtifact{}, fmt.Errorf("no kinematics artifact for gripper model %s", modelName)
 }
 
-// makeGeometryModel builds a zero-DoF kinematics model whose links carry geoms.
+const gripperStateJointID = "open_close"
+
+// makeGeometryModel builds a kinematics model whose links carry geoms.
 // Each geometry gets its own link, chained parent-to-child, because a link
 // config holds at most one geometry.
 //
@@ -78,7 +80,7 @@ func resolveGripperKinematicsArtifact(modelName string) (kinematicsArtifact, err
 // referenceframe.KinematicModelToProtobuf); without it the response carries no
 // kinematics data, the caller reconstructs an empty model, and the gripper lands
 // in the frame system with nothing to collide against.
-func makeGeometryModel(name string, geoms []spatialmath.Geometry) (referenceframe.Model, error) {
+func makeGeometryModel(name string, geoms []spatialmath.Geometry, addStateJoint bool) (referenceframe.Model, error) {
 	if len(geoms) == 0 {
 		return nil, fmt.Errorf("no geometries to build a kinematics model for %s", name)
 	}
@@ -99,6 +101,20 @@ func makeGeometryModel(name string, geoms []spatialmath.Geometry) (referencefram
 		cfg.Links = append(cfg.Links, *link)
 	}
 
+	if addStateJoint {
+		// Side branch off the last geometry; pin the primary output to the last
+		// geometry so downstream transforms don't shift with the joint value.
+		cfg.Joints = append(cfg.Joints, referenceframe.JointConfig{
+			ID:     gripperStateJointID,
+			Type:   referenceframe.PrismaticJoint,
+			Parent: parent,
+			Axis:   spatialmath.AxisConfig{X: 0, Y: 0, Z: 1},
+			Min:    0,
+			Max:    1,
+		})
+		cfg.OutputFrames = []string{parent}
+	}
+
 	raw, err := json.Marshal(cfg)
 	if err != nil {
 		return nil, err
@@ -111,11 +127,15 @@ func makeGeometryModel(name string, geoms []spatialmath.Geometry) (referencefram
 // newGripperKinematics builds the model a gripper reports to the frame system:
 // URDF-derived meshes when use_urdfs is set, otherwise a model carrying the
 // hand-authored bounding boxes that boxGeoms produces.
+//
+// addStateJoint applies only to the non-URDF path; ParseModelXMLFile
+// requires a single leaf and does not honor output_frames.
 func newGripperKinematics(
 	modelName string,
 	conf *GripperConfig,
 	logger logging.Logger,
 	boxGeoms func() ([]spatialmath.Geometry, error),
+	addStateJoint bool,
 ) (referenceframe.Model, error) {
 	if conf.UseURDFs {
 		return loadGripperModel(modelName, conf.MeshDecimationRatio, logger)
@@ -124,7 +144,7 @@ func newGripperKinematics(
 	if err != nil {
 		return nil, err
 	}
-	return makeGeometryModel(modelName, geoms)
+	return makeGeometryModel(modelName, geoms, addStateJoint)
 }
 
 const gripperDefaultMeshDecimationRatio = 0.1

--- a/arm/kinematics_test.go
+++ b/arm/kinematics_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestMakeGeometryModelRequiresGeometries(t *testing.T) {
-	_, err := makeGeometryModel(ModelNameGripper, nil)
+	_, err := makeGeometryModel(ModelNameGripper, nil, false)
 	test.That(t, err, test.ShouldNotBeNil)
 }
 
@@ -23,7 +23,7 @@ func TestMakeGeometryModelSurvivesGetKinematics(t *testing.T) {
 		r3.Vector{X: 50, Y: 100, Z: 100}, "case-gripper")
 	test.That(t, err, test.ShouldBeNil)
 
-	mf, err := makeGeometryModel(ModelNameGripper, []spatialmath.Geometry{box})
+	mf, err := makeGeometryModel(ModelNameGripper, []spatialmath.Geometry{box}, false)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, mf.ModelConfig().OriginalFile, test.ShouldNotBeNil)
 	test.That(t, mf.ModelConfig().OriginalFile.Extension, test.ShouldEqual, "json")
@@ -44,18 +44,24 @@ func TestGripperModelsCarryBoxesThroughGetKinematics(t *testing.T) {
 	logger := logging.NewTestLogger(t)
 
 	for _, tc := range []struct {
-		name  string
-		geoms func() ([]spatialmath.Geometry, error)
+		name          string
+		geoms         func() ([]spatialmath.Geometry, error)
+		addStateJoint bool
+		wantDoF       int
 	}{
-		{ModelNameGripper, standardGripperGeometries},
-		{ModelNameGripperLite, liteGripperGeometries},
+		{ModelNameGripper, standardGripperGeometries, true, 1},
+		{ModelNameGripperLite, liteGripperGeometries, true, 1},
 		{
 			ModelNameVacuumGripper,
 			func() ([]spatialmath.Geometry, error) { return vacuumGripperGeometries(VacuumGripperModel, 30) },
+			false,
+			0,
 		},
 		{
 			ModelNameVacuumGripperLite,
 			func() ([]spatialmath.Geometry, error) { return vacuumGripperGeometries(VacuumGripperModelLite, 0) },
+			false,
+			0,
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -63,12 +69,14 @@ func TestGripperModelsCarryBoxesThroughGetKinematics(t *testing.T) {
 			test.That(t, err, test.ShouldBeNil)
 			test.That(t, want, test.ShouldNotBeEmpty)
 
-			mf, err := newGripperKinematics(tc.name, &GripperConfig{}, logger, tc.geoms)
+			mf, err := newGripperKinematics(tc.name, &GripperConfig{}, logger, tc.geoms, tc.addStateJoint)
 			test.That(t, err, test.ShouldBeNil)
+			test.That(t, mf.DoF(), test.ShouldHaveLength, tc.wantDoF)
 
 			// Round-trip the way the module server and its caller do.
 			rebuilt, err := referenceframe.KinematicModelFromProtobuf(tc.name, referenceframe.KinematicModelToProtobuf(mf))
 			test.That(t, err, test.ShouldBeNil)
+			test.That(t, rebuilt.DoF(), test.ShouldHaveLength, tc.wantDoF)
 
 			got := modelGeometries(t, rebuilt)
 			test.That(t, got, test.ShouldHaveLength, len(want))
@@ -86,6 +94,29 @@ func TestGripperModelsCarryBoxesThroughGetKinematics(t *testing.T) {
 				test.That(t, spatialmath.GeometriesAlmostEqual(got[i], before[i]), test.ShouldBeTrue)
 			}
 		})
+	}
+}
+
+// Geometry output must be invariant across the state joint's input range —
+// otherwise consumers parented to the gripper shift with jaw state.
+func TestMakeGeometryModelStateJointDoesNotWarpGeometry(t *testing.T) {
+	geoms, err := standardGripperGeometries()
+	test.That(t, err, test.ShouldBeNil)
+
+	mf, err := makeGeometryModel(ModelNameGripper, geoms, true)
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, mf.DoF(), test.ShouldHaveLength, 1)
+
+	closed, err := mf.Geometries([]referenceframe.Input{gripperClosedInput})
+	test.That(t, err, test.ShouldBeNil)
+	open, err := mf.Geometries([]referenceframe.Input{gripperOpenInput})
+	test.That(t, err, test.ShouldBeNil)
+
+	closedGeoms := closed.Geometries()
+	openGeoms := open.Geometries()
+	test.That(t, closedGeoms, test.ShouldHaveLength, len(openGeoms))
+	for i := range closedGeoms {
+		test.That(t, spatialmath.GeometriesAlmostEqual(closedGeoms[i], openGeoms[i]), test.ShouldBeTrue)
 	}
 }
 

--- a/arm/vacuum_gripper.go
+++ b/arm/vacuum_gripper.go
@@ -89,9 +89,10 @@ func newVacuumGripper(ctx context.Context, deps resource.Dependencies, config re
 		return nil, err
 	}
 
+	// Vacuum grippers stay 0 DoF pending a design decision on suction state.
 	mf, err := newGripperKinematics(config.Model.Name, newConf, logger, func() ([]spatialmath.Geometry, error) {
 		return vacuumGripperGeometries(config.Model, newConf.VacuumLengthMM)
-	})
+	}, false)
 	if err != nil {
 		return nil, fmt.Errorf("%s kinematics: %w", config.Model.Name, err)
 	}


### PR DESCRIPTION
## What this PR does
Mechanical grippers now report 1 DoF. CurrentInputs returns [0] (closed) or [1] (open).

## Why
- If you use the client side frame system service (i.e. you're a module) it calls CurrentInputs on anything that is input enabled and thus returns an error. 
- Long term John N is going to implement this more correctly but this is to unblock that client side hurdle I'm experiencing

## Not changing: 
- Vacuum grippers unchanged, pending separate discussion on how to model suction state.
- GoToInputs remains ErrUnsupported; this exposes state only.
