### PR TITLE
gripper: no-op GoToInputs on mechanical grippers

### DIFF
--- a/arm/gripper.go
+++ b/arm/gripper.go
@@ -2,7 +2,6 @@ package arm
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"math"
 	"sync"
@@ -248,7 +247,7 @@ func (g *myGripperLite) CurrentInputs(ctx context.Context) ([]referenceframe.Inp
 }
 
 func (g *myGripperLite) GoToInputs(ctx context.Context, inputs ...[]referenceframe.Input) error {
-	return errors.ErrUnsupported
+	return nil
 }
 
 func (g *myGripperLite) Status(_ context.Context) (map[string]any, error) {
@@ -491,7 +490,7 @@ func (g *myGripper) CurrentInputs(ctx context.Context) ([]referenceframe.Input, 
 }
 
 func (g *myGripper) GoToInputs(ctx context.Context, inputs ...[]referenceframe.Input) error {
-	return errors.ErrUnsupported
+	return nil
 }
 
 func (g *myGripper) Status(_ context.Context) (map[string]any, error) {


### PR DESCRIPTION
Fixes "unsupported operation" errors on arm.MoveToPosition and any motion.Move path after the 1-DoF gripper change in

Root cause: builtIn.execute iterates every DoF frame in the trajectory and calls GoToInputs on each. Our gripper's GoToInputs still returned ErrUnsupported.

Vacuum grippers untouched which means that they won't work with the frame system service

I'm going to poke around at the built in motion service and see if we should only call GoToInputs when there is actually an input