### PR TITLE
gripper: honor 0-DoF contract on vacuum grippers

### DIFF
--- a/arm/vacuum_gripper.go
+++ b/arm/vacuum_gripper.go
@@ -2,7 +2,6 @@ package arm
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"sync/atomic"
 
@@ -271,11 +270,11 @@ func (g *myVacuumGripper) Kinematics(ctx context.Context) (referenceframe.Model,
 }
 
 func (g *myVacuumGripper) CurrentInputs(ctx context.Context) ([]referenceframe.Input, error) {
-	return nil, errors.ErrUnsupported
+	return []referenceframe.Input{}, nil
 }
 
 func (g *myVacuumGripper) GoToInputs(ctx context.Context, inputs ...[]referenceframe.Input) error {
-	return errors.ErrUnsupported
+	return nil
 }
 
 func (g *myVacuumGripper) Status(_ context.Context) (map[string]any, error) {


### PR DESCRIPTION
Vacuum grippers now honor their declared 0 DoF contract

I changed my mind and want to ensure vacuum grippers work with the frame system service