### PR TITLE
[APP-16395] Fix isHoldingSomething for gripper G2, add gripper G2 geometries and better submodel detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,19 +296,26 @@ Access Studio at `http://<viam-server-ip>:18333`. If port 18333 is in use, set `
 
 ## Gripper
 
-The standard two-finger gripper for xArm6/xArm7.
+The standard two-finger gripper for xArm6/xArm7, in both the G1 and the current G2 (AG1200) generation.
+
+The generation is detected at startup by probing for force control: the module reads the G2 control block at `0x0C00`, and a gripper that rejects it with a Modbus exception is a G1. Set `gripper_version` to skip detection entirely.
+
+On a G2 the module uses the force block-write for `Grab`/`Open` and reads the gripper's own object-detected bit for `IsHoldingSomething`
 
 ```json
 {
   "arm": "my-xarm",
-  "gripper_speed": 2000
+  "gripper_speed": 2000,
+  "gripper_force": 50
 }
 ```
 
 | Name | Type | Inclusion | Description |
 |------|------|-----------|-------------|
 | `arm` | string | **Required** | Name of the arm component this gripper is attached to. |
-| `gripper_speed` | int | Optional | Default speed on startup (1–5000). Uses firmware default if omitted. |
+| `gripper_version` | string | Optional | `"g1"` or `"g2"`. Bypasses detection entirely. Omit to detect from firmware version. |
+| `gripper_speed` | int | Optional | Default speed on startup (1–5000). G2 defaults to 2000; G1 is left on its firmware default (1500) when omitted. |
+| `gripper_force` | int | Optional | G2 only. Grasp force as a percentage (1–100). Defaults to 50. Ignored on a G1, which has no force register. |
 | `use_urdfs` | bool | Optional | When `true`, reports mesh-derived collision geometry from `xarm_gripper.urdf` (packaged in the module) instead of the default hand-authored bounding box. |
 | `mesh_decimation_ratio` | float64 | Optional | Only applies when `use_urdfs` is `true`. Simplification ratio in `(0, 1]` for the gripper mesh; `0` keeps it at full fidelity, `0.5` reduces it to 50% of its original triangle count. |
 

--- a/arm/comm.go
+++ b/arm/comm.go
@@ -1120,8 +1120,8 @@ func (x *xArm) setupGripper(ctx context.Context) error {
 	return nil
 }
 
-// disableGripperControlMode clears the FnC00 "Control Enable" register (0x0C00) set by graspWithTorque.
-// FnC00 enables the FnCxx block-write control mode (speed+torque+position); when left enabled,
+// disableGripperControlMode clears the FnC00 "Control Enable" register (0x0C00) set by the force-control
+// block write. FnC00 enables that block-write control mode (speed+torque+position); when left enabled,
 // subsequent standalone Fn700 position commands may not work reliably. See G2 manual section 4.1.7.
 // Writing the block also resets Fn303, so callers that need the configured speed must restore it.
 func (x *xArm) disableGripperControlMode(ctx context.Context) error {
@@ -1246,6 +1246,9 @@ func (x *xArm) getGripperSpeed(ctx context.Context) (uint16, error) {
 	return w[0], nil
 }
 
+// Standard-gripper status register (0x0000).
+const standardGripperStatusReg uint16 = 0x0000
+
 // gripperReadHeaderLen is the number of bytes ahead of the register payload in a
 // gripper-bus read response:
 // On a Modbus exception the function code comes back with its high bit set
@@ -1308,45 +1311,14 @@ func (r gripperRegRead) words() []uint16 {
 	return out
 }
 
-// graspWithTorque issues the FnCxx block-write (start address 0x0C00, 5 registers) so the gripper
-// applies the requested grasp current/torque atomically with the position move. See section 4.2 of
-// the G2 manual — this mirrors the Python SDK's set_gripper_g2_position(position, speed, force).
-func (x *xArm) graspWithTorque(ctx context.Context, speed, torque uint16, position uint32, stall time.Duration) error {
-	// Clear FnC00 first so the firmware sees a 0->1 transition on the new write,
-	// otherwise back-to-back grasp commands may be ignored while a hold is active.
-	if err := x.disableGripperControlMode(ctx); err != nil {
-		return err
-	}
-
-	c := x.gripperPreamble(true)
-	c.params = append(c.params, 0x0C, 0x00)
-	c.params = append(c.params, 0x00, 0x05)
-	c.params = append(c.params, 0x0A)
-
-	buf := make([]byte, 2)
-	binary.BigEndian.PutUint16(buf, 1) // FnC00 enable
-	c.params = append(c.params, buf...)
-	binary.BigEndian.PutUint16(buf, speed) // FnC01
-	c.params = append(c.params, buf...)
-	binary.BigEndian.PutUint16(buf, torque) // FnC02
-	c.params = append(c.params, buf...)
-
-	posBytes := make([]byte, 4)
-	binary.BigEndian.PutUint32(posBytes, position) // FnC03 high, FnC04 low
-	c.params = append(c.params, posBytes...)
-
-	x.logger.Debugf("graspWithTorque speed=%d torque=%d position=%d stall=%s", speed, torque, position, stall)
-	// Assume the mode is on before the write lands: a send that fails may still have enabled it,
-	// and wrongly believing it is off makes the next setupGripper skip the clear and the speed
-	// restore, which is the silent speed loss this whole path exists to avoid. Wrongly believing
-	// it is on only costs one extra register write.
-	x.gripperControlMode.Store(true)
-	if _, err := x.gripperSend(ctx, c); err != nil {
-		return err
-	}
-
-	return x.waitForGripper(ctx, int(position), stall)
-}
+// Low two bits of the gripper status register.
+const (
+	gripperStateMask     uint16 = 0x03
+	gripperStateStop     uint16 = 0
+	gripperStateMotion   uint16 = 1
+	gripperStateDetected uint16 = 2
+	gripperStateFault    uint16 = 3
+)
 
 // waitForGripper polls gripper position until it reaches goal (within 6),
 // stalls (no movement >1 for >stall), or 10s elapses as an overall backstop.

--- a/arm/detection.go
+++ b/arm/detection.go
@@ -43,6 +43,8 @@ const (
 	submodelV1   = "v1"
 	submodelV2   = "v2"
 	submodelLite = "lite"
+	submodelG1   = "g1"
+	submodelG2   = "g2"
 )
 
 // Two-letter SN prefixes UFactory burns into the controller banner. These are
@@ -208,49 +210,35 @@ func (x *xArm) detectVersion(ctx context.Context) (versionInfo, error) {
 
 // Modbus register start addresses used by gripper probes.
 const (
-	standardGripperVersionReg uint16 = 0x0801 // SOFT_VER, 3 consecutive regs: major.minor.patch
+	standardGripperVersionReg uint16 = 0x0801
 	bioGripperSNReg           uint16 = 0x0B10 // BIO serial-number block, up to 16 regs
 )
 
 func (x *xArm) detectStandardGripper(ctx context.Context) (detectedGripper, error) {
-	const numRegs = 3
-	c := x.gripperPreamble(false)
-	c.params = binary.BigEndian.AppendUint16(c.params, standardGripperVersionReg)
-	c.params = binary.BigEndian.AppendUint16(c.params, numRegs)
-	res, err := x.gripperSend(ctx, c)
+	r, err := x.readGripperRegisters(ctx, standardGripperVersionReg, 3)
 	if err != nil {
 		return unknownGripper(), err
 	}
-	const headerLen = 5
-	wantLen := headerLen + 2*numRegs
-	if len(res.params) < wantLen {
-		return unknownGripper(),
-			fmt.Errorf("standard gripper version response too short: got %d, want %d (%v)", len(res.params), wantLen, res.params)
+	if r.exception != 0 {
+		return unknownGripper(), fmt.Errorf("standard gripper version read rejected with Modbus exception 0x%02X (%v)", r.exception, r.params)
 	}
-	data := res.params[headerLen : headerLen+2*numRegs]
-	major := binary.BigEndian.Uint16(data[0:2])
-	minor := binary.BigEndian.Uint16(data[2:4])
-	patch := binary.BigEndian.Uint16(data[4:6])
+	v := r.words()
+	if len(v) != 3 {
+		return unknownGripper(), fmt.Errorf("standard gripper version response malformed: %v (%v)", v, r.params)
+	}
 	return detectedGripper{
-		kind:     gripperKindStandard,
-		version:  fmt.Sprintf("%d.%d.%d", major, minor, patch),
-		submodel: standardGripperSubmodel(major, minor, patch),
+		kind:    gripperKindStandard,
+		version: fmt.Sprintf("%d.%d.%d", v[0], v[1], v[2]),
 	}, nil
 }
 
-// standardGripperSubmodel splits at firmware >= 3.4.3, the gate for
-// status-register (0x0000) support on the standard gripper.
-func standardGripperSubmodel(major, minor, patch uint16) string {
-	switch {
-	case major > 3:
-		return submodelV2
-	case major == 3 && minor > 4:
-		return submodelV2
-	case major == 3 && minor == 4 && patch >= 3:
-		return submodelV2
-	default:
-		return submodelV1
+// submodelFromForceControlProbe turns a read of the FnCxx force-control block
+// into a G1 or G2 submodel.
+func submodelFromForceControlProbe(r gripperRegRead) string {
+	if r.exception != 0 {
+		return submodelG1
 	}
+	return submodelG2
 }
 
 // detectBioGripper: byteCount==2 means v1 (single-register response), 2*numRegs
@@ -284,6 +272,35 @@ func (x *xArm) detectBioGripper(ctx context.Context) (detectedGripper, error) {
 		return unknownGripper(),
 			fmt.Errorf("bio gripper unexpected byte count: %d (%v)", byteCount, res.params)
 	}
+}
+
+// resolveGripperSubmodel decides which hardware generation the standard gripper
+// is by probing for force control, and logs the firmware version on the way past.
+
+func resolveGripperSubmodel(ctx context.Context, x *xArm, logger logging.Logger) (detectedGripper, error) {
+	d := detectedGripper{kind: gripperKindStandard}
+
+	if fw, err := x.detectStandardGripper(ctx); err != nil {
+		logger.Warnf("standard gripper: could not read the firmware version: %v", err)
+	} else {
+		d = fw
+		logger.Infof("standard gripper: firmware %s", d.version)
+	}
+
+	r, err := x.readGripperRegisters(ctx, gripperControlModeReg, gripperForceControlRegs)
+	if err != nil {
+		return d, fmt.Errorf(
+			"standard gripper: cannot detect the generation: %w. Set gripper_version in the config to skip detection", err)
+	}
+	if r.exception != 0 {
+		logger.Debugf("standard gripper: force-control block rejected with Modbus exception 0x%02X (raw %v)", r.exception, r.params)
+	} else {
+		logger.Debugf("standard gripper: force-control block read back %v (raw %v)", r.words(), r.params)
+	}
+
+	d.submodel = submodelFromForceControlProbe(r)
+	logger.Infof("standard gripper: detected %s", d.submodel)
+	return d, nil
 }
 
 func probeGripper(ctx context.Context, a arm.Arm, kind gripperKind, logger logging.Logger) detectedGripper {

--- a/arm/detection_test.go
+++ b/arm/detection_test.go
@@ -88,25 +88,6 @@ func TestParseVersionBanner(t *testing.T) {
 	}
 }
 
-func TestStandardGripperSubmodel(t *testing.T) {
-	tests := []struct {
-		name              string
-		major, minor, pat uint16
-		want              string
-	}{
-		{"old major", 2, 9, 9, "v1"},
-		{"3.4.2 just below gate", 3, 4, 2, "v1"},
-		{"3.4.3 exact gate", 3, 4, 3, "v2"},
-		{"3.5.0 above gate", 3, 5, 0, "v2"},
-		{"4.0.0", 4, 0, 0, "v2"},
-	}
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			test.That(t, standardGripperSubmodel(tc.major, tc.minor, tc.pat), test.ShouldEqual, tc.want)
-		})
-	}
-}
-
 func TestVacuumGripperSubmodel(t *testing.T) {
 	tests := []struct {
 		name string
@@ -176,4 +157,18 @@ func TestDecodehardwareModel(t *testing.T) {
 			test.That(t, got, test.ShouldEqual, tc.want)
 		})
 	}
+}
+
+// Generation detection, from the bytes the controller actually sent. Frames
+// captured verbatim from a real G1 on firmware 3.6.0 and a real G2 on 5.2.1: the
+// G1 rejects the force-control block, the G2 reads it back.
+func TestSubmodelFromForceControlProbe(t *testing.T) {
+	g1, err := decodeGripperRegRead(gripperControlModeReg, gripperForceControlRegs, []byte{16, 9, 8, 131, 2})
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, submodelFromForceControlProbe(g1), test.ShouldEqual, submodelG1)
+
+	g2, err := decodeGripperRegRead(gripperControlModeReg, gripperForceControlRegs,
+		[]byte{0, 9, 8, 3, 10, 0, 0, 0, 100, 0, 50, 0, 0, 0, 0})
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, submodelFromForceControlProbe(g2), test.ShouldEqual, submodelG2)
 }

--- a/arm/gripper.go
+++ b/arm/gripper.go
@@ -15,6 +15,7 @@ import (
 	"go.viam.com/rdk/referenceframe"
 	"go.viam.com/rdk/resource"
 	"go.viam.com/rdk/spatialmath"
+	rutils "go.viam.com/rdk/utils"
 	"go.viam.com/utils"
 )
 
@@ -32,14 +33,38 @@ var (
 	GripperModelLite = family.WithModel(ModelNameGripperLite)
 )
 
+// Raw Fn700/Fn702 pulse thresholds. The register scale (0..850 over the full
+// stroke) is the same on G1 and G2 — only the millimetre mapping differs, and we
+// never expose millimetres — so these serve both. On G2 they are a fallback:
+// holding is read from the status register instead.
 const fullyClosedThreshold = 10
 const fullyOpenThreshold = 830
+const fullyOpenPosition = 840
+
+// G2 defaults. Speed is in raw Fn303/FnC01 pulses: UFactory's documented G2
+// default is 2000 (G1's is 1500, which we leave to the gripper's own firmware
+// rather than writing it). Force is the 1-100 percentage the SDKs default to in
+// set_gripper_g2_position.
+const (
+	defaultGripperSpeedG2 = 2000
+	defaultGripperForceG2 = 50
+)
+
+// gripperStatusTimeout bounds the G2 move poll, matching the SDKs' 10s default.
+const gripperStatusTimeout = 10 * time.Second
 
 // GripperConfig config for gripper.
 type GripperConfig struct {
 	Arm            string
 	VacuumLengthMM float64 `json:"vacuum_length_mm"`
 	GripperSpeed   int     `json:"gripper_speed,omitempty"`
+	// GripperVersion pins the standard gripper's hardware generation to "g1" or
+	// "g2", bypassing detection completely. Empty (the default) detects it by
+	// probing for force-control support.
+	GripperVersion string `json:"gripper_version,omitempty"`
+	// GripperForce is the G2 grasp force as a percentage, 1-100. Ignored on G1,
+	// which has no force register. 0 means defaultGripperForceG2.
+	GripperForce int `json:"gripper_force,omitempty"`
 	// ConnectionType overrides vacuum wiring detection: "plugin" or "contact".
 	// Empty means auto-detect from the arm model.
 	ConnectionType string `json:"connection_type,omitempty"`
@@ -62,6 +87,14 @@ func (cfg *GripperConfig) Validate(path string) ([]string, []string, error) {
 	}
 	if cfg.GripperSpeed != 0 && (cfg.GripperSpeed < 1 || cfg.GripperSpeed > 5000) {
 		return nil, nil, fmt.Errorf("gripper_speed must be between 1 and 5000, got %d", cfg.GripperSpeed)
+	}
+	switch cfg.GripperVersion {
+	case "", submodelG1, submodelG2:
+	default:
+		return nil, nil, fmt.Errorf(`gripper_version must be %q or %q, got %q`, submodelG1, submodelG2, cfg.GripperVersion)
+	}
+	if cfg.GripperForce != 0 && (cfg.GripperForce < 1 || cfg.GripperForce > 100) {
+		return nil, nil, fmt.Errorf("gripper_force must be between 1 and 100, got %d", cfg.GripperForce)
 	}
 	switch cfg.ConnectionType {
 	case "", string(connectionPlugin), string(connectionContact):
@@ -251,6 +284,8 @@ type myGripper struct {
 	isMoving         atomic.Bool
 
 	detected detectedGripper
+	// speed and force are the resolved G2 FnCxx parameters. Unused on G1.
+	speed, force uint16
 
 	logger logging.Logger
 }
@@ -261,7 +296,34 @@ func newGripper(ctx context.Context, deps resource.Dependencies, config resource
 		return nil, err
 	}
 
-	mf, err := newGripperKinematics(ModelNameGripper, newConf, logger, standardGripperGeometries)
+	a, err := arm.FromProvider(deps, newConf.Arm)
+	if err != nil {
+		return nil, err
+	}
+
+	x, err := rutils.AssertType[*xArm](a)
+	if err != nil {
+		return nil, fmt.Errorf("standard gripper: %w", err)
+	}
+
+	// A pinned gripper_version is taken at face value; otherwise probe. Either way
+	// this has to settle before the kinematics model is built, because G1 and G2
+	// report different collision geometry.
+	detected := detectedGripper{kind: gripperKindStandard, submodel: newConf.GripperVersion}
+	if newConf.GripperVersion != "" {
+		logger.Infof("standard gripper: configured as %s, skipping detection", newConf.GripperVersion)
+	} else if detected, err = resolveGripperSubmodel(ctx, x, logger); err != nil {
+		return nil, err
+	}
+	submodel := detected.submodel
+
+	if newConf.UseURDFs && submodel == submodelG2 {
+		logger.Warn("gripper: use_urdfs is set but only the G1 mesh ships, so this G2 will report G1 collision geometry; " +
+			"unset use_urdfs to get the G2 bounding boxes")
+	}
+	mf, err := newGripperKinematics(ModelNameGripper, newConf, logger, func() ([]spatialmath.Geometry, error) {
+		return standardGripperGeometries(submodel)
+	}, true)
 	if err != nil {
 		return nil, fmt.Errorf("gripper kinematics: %w", err)
 	}
@@ -270,20 +332,28 @@ func newGripper(ctx context.Context, deps resource.Dependencies, config resource
 		name:     config.ResourceName(),
 		mf:       mf,
 		useURDFs: newConf.UseURDFs,
+		arm:      a,
+		detected: detected,
+		force:    defaultGripperForceG2,
 		logger:   logger,
 	}
-
-	g.arm, err = arm.FromProvider(deps, newConf.Arm)
-	if err != nil {
-		return nil, err
+	if newConf.GripperForce != 0 {
+		g.force = uint16(newConf.GripperForce) //nolint:gosec // Validate bounds it to 1-100.
 	}
 
-	g.detected = probeGripper(ctx, g.arm, gripperKindStandard, logger)
-
+	// G1 keeps its historical behaviour: only write Fn303 when the user asked for a
+	// speed, otherwise leave the gripper on its own 1500 default. The G2 runs it
+	// unconditionally for the setupGripper side effect — the gripper has to be
+	// enabled before the first force-control write, and nothing else does that.
+	g.speed = defaultGripperSpeedG2
 	if newConf.GripperSpeed != 0 {
-		if _, err := g.arm.DoCommand(ctx, map[string]any{
-			setGripperSpeedKey: float64(newConf.GripperSpeed),
-		}); err != nil {
+		g.speed = uint16(newConf.GripperSpeed)
+	}
+	if newConf.GripperSpeed != 0 || submodel == submodelG2 {
+		if err := x.setupGripper(ctx); err != nil {
+			return nil, fmt.Errorf("failed to set up gripper: %w", err)
+		}
+		if err := x.setGripperSpeed(ctx, g.speed); err != nil {
 			return nil, fmt.Errorf("failed to set gripper speed: %w", err)
 		}
 	}
@@ -291,7 +361,29 @@ func newGripper(ctx context.Context, deps resource.Dependencies, config resource
 	return g, nil
 }
 
+// bus resolves the arm to the concrete type that owns the gripper Modbus
+// transport.
+func (g *myGripper) bus() (*xArm, error) {
+	return rutils.AssertType[*xArm](g.arm)
+}
+
+// submodel is submodelG1 or submodelG2 and selects the grasp protocol: G1 uses
+// the plain Fn700 position move plus a position-stall poll, G2 the force
+// block-write plus the status register.
+func (g *myGripper) submodel() string {
+	return g.detected.submodel
+}
+
 func (g *myGripper) Grab(ctx context.Context, extra map[string]any) (bool, error) {
+	// G2 closes to 0, matching the SDK's clamp; G1 keeps its historical target of 2.
+	if g.submodel() == submodelG2 {
+		status, err := g.moveG2(ctx, 0)
+		if err != nil {
+			return false, err
+		}
+		return status&gripperStateMask == gripperStateDetected, nil
+	}
+
 	pos, err := g.goToPosition(ctx, 2)
 	if err != nil {
 		return false, err
@@ -301,14 +393,41 @@ func (g *myGripper) Grab(ctx context.Context, extra map[string]any) (bool, error
 }
 
 func (g *myGripper) Open(ctx context.Context, extra map[string]any) error {
-	_, err := g.goToPosition(ctx, 840)
+	if g.submodel() == submodelG2 {
+		_, err := g.moveG2(ctx, fullyOpenPosition)
+		return err
+	}
+
+	_, err := g.goToPosition(ctx, fullyOpenPosition)
 	return err
 }
 
+// IsHoldingSomething reports the G2's own object-detected bit, which is
+// authoritative the instant it is read. The G1 has no status register, so it
+// keeps inferring holding from where the jaws came to rest.
 func (g *myGripper) IsHoldingSomething(
 	ctx context.Context,
 	extra map[string]any,
 ) (gripper.HoldingStatus, error) {
+	if g.submodel() == submodelG2 {
+		status, err := g.getStatus(ctx)
+		if err != nil {
+			return gripper.HoldingStatus{}, err
+		}
+		meta := map[string]any{"status": status}
+		// Position is best-effort here: it is useful telemetry but must not turn
+		// a good holding answer into an error.
+		if pos, err := g.getPosition(ctx); err == nil {
+			meta["position"] = pos
+		} else {
+			g.logger.Debugf("gripper position read failed during IsHoldingSomething: %v", err)
+		}
+		return gripper.HoldingStatus{
+			IsHoldingSomething: status&gripperStateMask == gripperStateDetected,
+			Meta:               meta,
+		}, nil
+	}
+
 	pos, err := g.getPosition(ctx)
 	if err != nil {
 		return gripper.HoldingStatus{}, err
@@ -324,6 +443,111 @@ func (g *myGripper) IsHoldingSomething(
 	}, nil
 }
 
+// gripperForceControlRegs is the FnCxx block: enable, speed, force, position
+// high, position low. Writing it applies force atomically with the move — the G1
+// has no equivalent, which is also how the two are told apart.
+const gripperForceControlRegs = 5
+
+// writeForceControlBlock issues the G2 grasp write. Clearing FnC00 first makes the
+// firmware see a 0->1 transition on the new write; without it, back-to-back
+// grasps can be ignored while a hold is active.
+//
+// Package-level rather than a method so the arm's grab_with_torque DoCommand can
+// share the one definition of this frame.
+func writeForceControlBlock(ctx context.Context, x *xArm, speed, force uint16, position uint32) error {
+	if err := x.disableGripperControlMode(ctx); err != nil {
+		return err
+	}
+	return x.writeGripperRegisters(ctx, gripperControlModeReg, []uint16{
+		1,
+		speed,
+		force,
+		uint16(position >> 16),    //nolint:gosec // split of a 32-bit value.
+		uint16(position & 0xFFFF), //nolint:gosec
+	})
+}
+
+// moveG2 issues the force block-write and waits on the status register,
+// returning the status that ended the move.
+func (g *myGripper) moveG2(ctx context.Context, goal int) (uint16, error) {
+	g.goToPositionLock.Lock()
+	defer g.goToPositionLock.Unlock()
+
+	g.isMoving.Store(true)
+	defer g.isMoving.Store(false)
+
+	x, err := g.bus()
+	if err != nil {
+		return 0, err
+	}
+	if err := writeForceControlBlock(ctx, x, g.speed, g.force, uint32(goal)); err != nil { //nolint:gosec // goal is 0..850.
+		return 0, err
+	}
+
+	return g.waitForStatus(ctx, gripperStatusTimeout)
+}
+
+// waitForStatus mirrors _check_gripper_status in both UFactory SDKs: a move is
+// only complete once the controller has reported IS_MOTION and then settled back
+// to IS_STOP or IS_DETECTED. Treating the first idle reading as "done" is what
+// forced callers to sleep before IsHoldingSomething — immediately after the
+// write the gripper has not begun moving, so its status and position still
+// describe the previous pose. If motion never starts (already at the goal), the
+// SDKs give up after 20 polls and call it done; we do the same.
+func (g *myGripper) waitForStatus(ctx context.Context, timeout time.Duration) (uint16, error) {
+	const pollInterval = 100 * time.Millisecond
+	const notStartedPolls = 20
+
+	started := false
+	notStarted := 0
+	deadline := time.Now().Add(timeout)
+	var status uint16
+
+	for time.Now().Before(deadline) {
+		if !utils.SelectContextOrWait(ctx, pollInterval) {
+			return status, ctx.Err()
+		}
+		var err error
+		if status, err = g.getStatus(ctx); err != nil {
+			return status, err
+		}
+		switch status & gripperStateMask {
+		case gripperStateFault:
+			return status, fmt.Errorf("gripper reported a fault (status 0x%04x)", status)
+		case gripperStateMotion:
+			started = true
+		default: // gripperStateStop or gripperStateDetected
+			if started {
+				return status, nil
+			}
+			notStarted++
+			if notStarted >= notStartedPolls {
+				return status, nil
+			}
+		}
+	}
+	return status, fmt.Errorf("gripper move did not complete within %s (status 0x%04x)", timeout, status)
+}
+
+func (g *myGripper) getStatus(ctx context.Context) (uint16, error) {
+	x, err := g.bus()
+	if err != nil {
+		return 0, err
+	}
+	r, err := x.readGripperRegisters(ctx, standardGripperStatusReg, 1)
+	if err != nil {
+		return 0, err
+	}
+	if r.exception != 0 {
+		return 0, fmt.Errorf("gripper status read rejected with Modbus exception 0x%02X (%v)", r.exception, r.params)
+	}
+	w := r.words()
+	if len(w) != 1 {
+		return 0, fmt.Errorf("bad gripper status response %v", r.params)
+	}
+	return w[0], nil
+}
+
 func (g *myGripper) goToPosition(ctx context.Context, goal int) (int, error) {
 	g.goToPositionLock.Lock()
 	defer g.goToPositionLock.Unlock()
@@ -331,11 +555,14 @@ func (g *myGripper) goToPosition(ctx context.Context, goal int) (int, error) {
 	g.isMoving.Store(true)
 	defer g.isMoving.Store(false)
 
-	_, err := g.arm.DoCommand(ctx, map[string]any{
-		"setup_gripper": true,
-		"move_gripper":  float64(goal),
-	})
+	x, err := g.bus()
 	if err != nil {
+		return 0, err
+	}
+	if err := x.setupGripper(ctx); err != nil {
+		return 0, err
+	}
+	if err := x.setGripperPosition(ctx, uint32(goal)); err != nil { //nolint:gosec // goal is 0..850.
 		return 0, err
 	}
 
@@ -377,19 +604,12 @@ func (g *myGripper) goToPosition(ctx context.Context, goal int) (int, error) {
 }
 
 func (g *myGripper) getPosition(ctx context.Context) (int, error) {
-	res, err := g.arm.DoCommand(ctx, map[string]any{
-		getGripperKey: true,
-	})
+	x, err := g.bus()
 	if err != nil {
 		return 0, err
 	}
-
-	raw := res[gripperPositionKey]
-	pos, ok := raw.(float64)
-	if !ok {
-		return 0, fmt.Errorf("bad gripper_position (%v) %T", raw, raw)
-	}
-	return int(pos), nil
+	pos, err := x.getGripperPosition(ctx)
+	return int(pos), err
 }
 
 func (g *myGripper) Name() resource.Name {
@@ -451,7 +671,7 @@ func (g *myGripper) Geometries(ctx context.Context, _ map[string]any) ([]spatial
 		}
 		return gif.Geometries(), nil
 	}
-	return standardGripperGeometries()
+	return standardGripperGeometries(g.submodel())
 }
 
 func (g *myGripper) Kinematics(ctx context.Context) (referenceframe.Model, error) {
@@ -470,17 +690,20 @@ func (g *myGripper) Status(_ context.Context) (map[string]any, error) {
 	return map[string]any{}, nil
 }
 
-// standardGripperGeometries returns hand-authored bounding boxes for the
-// housing and open-jaw envelope. Used when use_urdfs is false.
-func standardGripperGeometries() ([]spatialmath.Geometry, error) {
+func standardGripperGeometries(version string) ([]spatialmath.Geometry, error) {
 	caseBoxSize := r3.Vector{X: 50, Y: 100, Z: 100}
+	clawSize := r3.Vector{X: 40, Y: 170, Z: 105}
+	if version == submodelG2 {
+		caseBoxSize = r3.Vector{X: 75, Y: 110, Z: 110}
+		clawSize = r3.Vector{X: 45, Y: 120, Z: 112}
+	}
+
 	caseBox, err := spatialmath.NewBox(
 		spatialmath.NewPoseFromPoint(r3.Vector{X: 0, Y: 0, Z: caseBoxSize.Z / -2}),
 		caseBoxSize, "case-gripper")
 	if err != nil {
 		return nil, err
 	}
-	clawSize := r3.Vector{X: 40, Y: 170, Z: 105}
 	claws, err := spatialmath.NewBox(
 		spatialmath.NewPoseFromPoint(r3.Vector{Z: 50 + (clawSize.Z / -2)}),
 		clawSize, "claws")

--- a/arm/gripper.go
+++ b/arm/gripper.go
@@ -323,7 +323,7 @@ func newGripper(ctx context.Context, deps resource.Dependencies, config resource
 	}
 	mf, err := newGripperKinematics(ModelNameGripper, newConf, logger, func() ([]spatialmath.Geometry, error) {
 		return standardGripperGeometries(submodel)
-	}, true)
+	})
 	if err != nil {
 		return nil, fmt.Errorf("gripper kinematics: %w", err)
 	}

--- a/arm/gripper_test.go
+++ b/arm/gripper_test.go
@@ -18,3 +18,13 @@ func TestGripperConfigValidateConnectionType(t *testing.T) {
 	test.That(t, err, test.ShouldNotBeNil)
 	test.That(t, err.Error(), test.ShouldContainSubstring, "connection_type")
 }
+
+func TestGripperConfigValidateVersionAndForce(t *testing.T) {
+	_, _, err := (&GripperConfig{Arm: "a", GripperVersion: "G3"}).Validate("p")
+	test.That(t, err, test.ShouldNotBeNil)
+	test.That(t, err.Error(), test.ShouldContainSubstring, "gripper_version")
+
+	_, _, err = (&GripperConfig{Arm: "a", GripperForce: 101}).Validate("p")
+	test.That(t, err, test.ShouldNotBeNil)
+	test.That(t, err.Error(), test.ShouldContainSubstring, "gripper_force")
+}

--- a/arm/kinematics_test.go
+++ b/arm/kinematics_test.go
@@ -50,10 +50,8 @@ func TestGripperModelsCarryBoxesThroughGetKinematics(t *testing.T) {
 		{
 			ModelNameGripper,
 			func() ([]spatialmath.Geometry, error) { return standardGripperGeometries(submodelG2) },
-			true,
-			1,
 		},
-		{ModelNameGripperLite, liteGripperGeometries, true, 1},
+		{ModelNameGripperLite, liteGripperGeometries},
 		{
 			ModelNameVacuumGripper,
 			func() ([]spatialmath.Geometry, error) { return vacuumGripperGeometries(VacuumGripperModel, 30) },
@@ -93,29 +91,6 @@ func TestGripperModelsCarryBoxesThroughGetKinematics(t *testing.T) {
 				test.That(t, spatialmath.GeometriesAlmostEqual(got[i], before[i]), test.ShouldBeTrue)
 			}
 		})
-	}
-}
-
-// Geometry output must be invariant across the state joint's input range —
-// otherwise consumers parented to the gripper shift with jaw state.
-func TestMakeGeometryModelStateJointDoesNotWarpGeometry(t *testing.T) {
-	geoms, err := standardGripperGeometries(submodelG2)
-	test.That(t, err, test.ShouldBeNil)
-
-	mf, err := makeGeometryModel(ModelNameGripper, geoms, true)
-	test.That(t, err, test.ShouldBeNil)
-	test.That(t, mf.DoF(), test.ShouldHaveLength, 1)
-
-	closed, err := mf.Geometries([]referenceframe.Input{gripperClosedInput})
-	test.That(t, err, test.ShouldBeNil)
-	open, err := mf.Geometries([]referenceframe.Input{gripperOpenInput})
-	test.That(t, err, test.ShouldBeNil)
-
-	closedGeoms := closed.Geometries()
-	openGeoms := open.Geometries()
-	test.That(t, closedGeoms, test.ShouldHaveLength, len(openGeoms))
-	for i := range closedGeoms {
-		test.That(t, spatialmath.GeometriesAlmostEqual(closedGeoms[i], openGeoms[i]), test.ShouldBeTrue)
 	}
 }
 

--- a/arm/kinematics_test.go
+++ b/arm/kinematics_test.go
@@ -47,8 +47,13 @@ func TestGripperModelsCarryBoxesThroughGetKinematics(t *testing.T) {
 		name  string
 		geoms func() ([]spatialmath.Geometry, error)
 	}{
-		{ModelNameGripper, standardGripperGeometries},
-		{ModelNameGripperLite, liteGripperGeometries},
+		{
+			ModelNameGripper,
+			func() ([]spatialmath.Geometry, error) { return standardGripperGeometries(submodelG2) },
+			true,
+			1,
+		},
+		{ModelNameGripperLite, liteGripperGeometries, true, 1},
 		{
 			ModelNameVacuumGripper,
 			func() ([]spatialmath.Geometry, error) { return vacuumGripperGeometries(VacuumGripperModel, 30) },
@@ -88,6 +93,29 @@ func TestGripperModelsCarryBoxesThroughGetKinematics(t *testing.T) {
 				test.That(t, spatialmath.GeometriesAlmostEqual(got[i], before[i]), test.ShouldBeTrue)
 			}
 		})
+	}
+}
+
+// Geometry output must be invariant across the state joint's input range —
+// otherwise consumers parented to the gripper shift with jaw state.
+func TestMakeGeometryModelStateJointDoesNotWarpGeometry(t *testing.T) {
+	geoms, err := standardGripperGeometries(submodelG2)
+	test.That(t, err, test.ShouldBeNil)
+
+	mf, err := makeGeometryModel(ModelNameGripper, geoms, true)
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, mf.DoF(), test.ShouldHaveLength, 1)
+
+	closed, err := mf.Geometries([]referenceframe.Input{gripperClosedInput})
+	test.That(t, err, test.ShouldBeNil)
+	open, err := mf.Geometries([]referenceframe.Input{gripperOpenInput})
+	test.That(t, err, test.ShouldBeNil)
+
+	closedGeoms := closed.Geometries()
+	openGeoms := open.Geometries()
+	test.That(t, closedGeoms, test.ShouldHaveLength, len(openGeoms))
+	for i := range closedGeoms {
+		test.That(t, spatialmath.GeometriesAlmostEqual(closedGeoms[i], openGeoms[i]), test.ShouldBeTrue)
 	}
 }
 

--- a/arm/xarm.go
+++ b/arm/xarm.go
@@ -792,7 +792,10 @@ func (x *xArm) DoCommand(ctx context.Context, cmd map[string]any) (map[string]an
 			}
 			stall = time.Duration(stallF * float64(time.Second))
 		}
-		if err := x.graspWithTorque(ctx, uint16(speedF), uint16(torqueF), uint32(positionF), stall); err != nil {
+		if err := writeForceControlBlock(ctx, x, uint16(speedF), uint16(torqueF), uint32(positionF)); err != nil {
+			return nil, err
+		}
+		if err := x.waitForGripper(ctx, int(positionF), stall); err != nil {
 			return nil, err
 		}
 		validCommand = true


### PR DESCRIPTION
UFactory no longer sells the G1, and the G2 differs enough to need its own
path: force control, a status register, a shorter stroke and a different
envelope.

Detection probes the FnCxx force-control block at 0x0C00. A gripper that
rejects it with a Modbus exception is a G1; one that reads it back is a G2.
Verified against both generations on hardware. Firmware version is read and
logged but deliberately never used to decide — a G1 on current firmware
(measured 3.6.0) clears the 3.4.3 status-register gate the SDKs use, so any
firmware threshold misidentifies exactly the units this exists to catch. The
G2 force register at 0x0500 is not usable either: a G1 answers it with 0
rather than rejecting it. gripper_version pins the generation and skips the
probe; a gripper we cannot probe is an error rather than a guess.

Grasping splits on that answer. G2 writes the force block (position, speed,
force) and waits on the status register, mirroring _check_gripper_status in
both SDKs: an idle status is only believed once motion has been observed.
That is the fix for IsHoldingSomething needing a client-side sleep — it now
reads the gripper's own object-detected bit and is correct immediately. G1
keeps the Fn700 position move and the position-stall poll unchanged.

Adds gripper_force (1-100, G2 only) and G2 collision geometry.

Not yet validated on hardware since the bus refactor underneath it.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>