### PR TITLE
add setting load docommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,38 @@ resp, err := xArmComponent.DoCommand(ctx, map[string]interface{}{"load": ""})
 // resp["load"] contains a []float64 of per-joint torque values
 ```
 
+### Payload (TCP Load)
+
+Set the payload weight and center of gravity the firmware uses for gravity
+compensation and collision detection — equivalent to the payload setting in
+UFactory Studio. The center of gravity is x, y, z in millimeters relative to the
+tool flange frame.
+
+**Go:**
+```go
+xArmComponent.DoCommand(ctx, map[string]interface{}{
+    "set_load": map[string]interface{}{
+        "weight_kg":            0.82,
+        "center_of_gravity_mm": []interface{}{0.0, 0.0, 48.0},
+        "save":                 true, // optional: persist across controller reboots
+    },
+})
+```
+
+**Python:**
+```python
+await arm.do_command({"set_load": {
+    "weight_kg": 0.82,
+    "center_of_gravity_mm": [0, 0, 48],
+    "save": True,  # optional: persist across controller reboots
+}})
+```
+
+> [!WARNING]
+> An incorrect payload configuration makes gravity compensation inaccurate: the
+> arm may drift in manual mode and collision detection may false-trigger or miss
+> real collisions.
+
 ### UFactory Gripper Control (via arm DoCommand)
 
 > [!NOTE]

--- a/arm/comm.go
+++ b/arm/comm.go
@@ -43,6 +43,8 @@ var regMap = map[string]byte{
 	"ClearWarn":      0x11,
 	"SetMode":        0x13,
 	"P2PJoint":       0x17,
+	"SetLoad":        0x24,
+	"SaveConf":       0x28,
 	"MoveJoints":     0x1D,
 	"ZeroJoints":     0x19,
 	"JointPos":       0x2A,
@@ -1542,6 +1544,27 @@ func (x *xArm) getLoad(ctx context.Context) ([]float64, error) {
 	}
 
 	return loads, nil
+}
+
+// setLoad sets the arm's TCP payload
+// The setting is lost on controller reboot unless persisted with saveConf.
+func (x *xArm) setLoad(ctx context.Context, weightKg float64, cogMM [3]float64) error {
+	c := x.newCmd(regMap["SetLoad"])
+	fBytes := make([]byte, 4)
+	for _, v := range []float64{weightKg, cogMM[0], cogMM[1], cogMM[2]} {
+		binary.LittleEndian.PutUint32(fBytes, math.Float32bits(float32(v)))
+		c.params = append(c.params, fBytes...)
+	}
+	_, err := x.send(ctx, c, true)
+	return err
+}
+
+// saveConf persists the controller's current configuration (payload, TCP offset, etc.)
+// across reboots.
+func (x *xArm) saveConf(ctx context.Context) error {
+	c := x.newCmd(regMap["SaveConf"])
+	_, err := x.send(ctx, c, true)
+	return err
 }
 
 // parseFTSensorData parses FTSensorData (0xC8): params[0] is a status byte, then six

--- a/arm/xarm.go
+++ b/arm/xarm.go
@@ -62,6 +62,7 @@ const (
 	getGripperSpeedKey       = "get_gripper_speed"
 	gripperSpeedKey          = "gripper_speed"
 	grabWithTorqueKey        = "grab_with_torque"
+	setLoadKey               = "set_load"
 	enterManualModeKey       = "enter_manual_mode"
 	exitManualModeKey        = "exit_manual_mode"
 	getFTSensorDataKey       = "get_ft_sensor_data"
@@ -823,6 +824,43 @@ func (x *xArm) DoCommand(ctx context.Context, cmd map[string]any) (map[string]an
 		validCommand = true
 	}
 
+	if val, ok := cmd[setLoadKey]; ok {
+		params, ok := val.(map[string]any)
+		if !ok {
+			return nil, fmt.Errorf("%s must be a map with keys weight_kg and center_of_gravity_mm; got %T", setLoadKey, val)
+		}
+		weight, err := utils.AssertType[float64](params["weight_kg"])
+		if err != nil {
+			return nil, fmt.Errorf("set_load.weight_kg: %w", err)
+		}
+		if weight < 0 {
+			return nil, fmt.Errorf("set_load.weight_kg cannot be negative, got %v", weight)
+		}
+		cogRaw, err := utils.AssertType[[]any](params["center_of_gravity_mm"])
+		if err != nil {
+			return nil, fmt.Errorf("set_load.center_of_gravity_mm: %w", err)
+		}
+		if len(cogRaw) != 3 {
+			return nil, fmt.Errorf("set_load.center_of_gravity_mm must have exactly 3 values (x, y, z), got %d", len(cogRaw))
+		}
+		var cog [3]float64
+		for i, v := range cogRaw {
+			f, err := utils.AssertType[float64](v)
+			if err != nil {
+				return nil, fmt.Errorf("set_load.center_of_gravity_mm[%d]: %w", i, err)
+			}
+			cog[i] = f
+		}
+		if err := x.setLoad(ctx, weight, cog); err != nil {
+			return nil, err
+		}
+		if save, _ := params["save"].(bool); save {
+			if err := x.saveConf(ctx); err != nil {
+				return nil, err
+			}
+		}
+		validCommand = true
+	}
 	if _, ok := cmd[loadKey]; ok {
 		loadInformation, err := x.getLoad(ctx)
 		if err != nil {

--- a/arm/xarm_test.go
+++ b/arm/xarm_test.go
@@ -1,6 +1,7 @@
 package arm
 
 import (
+	"context"
 	"math"
 	"os"
 	"path/filepath"
@@ -24,6 +25,28 @@ func TestConnectionTypeFromCmd(t *testing.T) {
 		test.ShouldEqual, connectionPlugin)
 	test.That(t, connectionTypeFromCmd(map[string]any{connectionTypeKey: "nonsense"}, submodelV1),
 		test.ShouldEqual, connectionPlugin)
+}
+
+func TestDoCommandSetLoadValidation(t *testing.T) {
+	x := &xArm{}
+	for _, tc := range []struct {
+		name string
+		val  any
+		msg  string
+	}{
+		{"not a map", 5.0, "must be a map"},
+		{"missing weight", map[string]any{"center_of_gravity_mm": []any{0.0, 0.0, 0.0}}, "weight_kg"},
+		{"negative weight", map[string]any{"weight_kg": -1.0, "center_of_gravity_mm": []any{0.0, 0.0, 0.0}}, "cannot be negative"},
+		{"missing cog", map[string]any{"weight_kg": 1.0}, "center_of_gravity_mm"},
+		{"wrong cog length", map[string]any{"weight_kg": 1.0, "center_of_gravity_mm": []any{0.0, 0.0}}, "exactly 3"},
+		{"non-numeric cog", map[string]any{"weight_kg": 1.0, "center_of_gravity_mm": []any{0.0, "x", 0.0}}, "center_of_gravity_mm[1]"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := x.DoCommand(context.Background(), map[string]any{setLoadKey: tc.val})
+			test.That(t, err, test.ShouldNotBeNil)
+			test.That(t, err.Error(), test.ShouldContainSubstring, tc.msg)
+		})
+	}
 }
 
 // armDir returns the absolute path to the arm/ directory containing test data.


### PR DESCRIPTION
Adds being able to set payload and center of gravity for ufactory arms using docommands.

Confirmed working using a ufactory 850 and checked the TCP settings screen before and after running this do command: 
```{
  "set_load": {
    "weight_kg": 1,
    "center_of_gravity_mm": [0,1,0],
    "save": true
  }
}
```

and I confirmed it was updated in Ufactory Studio:
<img width="1467" height="705" alt="Screenshot 2026-08-21 at 12 54 52 PM" src="https://github.com/user-attachments/assets/ec7c2450-3581-41e4-b9bc-b4aeb30e47e0" />
