### PR TITLE
Expose current runtime arm speed

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,10 @@ The following commands are available via `DoCommand` on the arm component.
 // Set speed (degrees/second)
 xArmComponent.DoCommand(ctx, map[string]interface{}{"set_speed": 50.0})
 
+// Get the current speed (degrees/second)
+resp, _ := xArmComponent.DoCommand(ctx, map[string]interface{}{"get_speed": true})
+// resp["speed_degs_per_sec"] contains the current runtime speed
+
 // Set acceleration (degrees/second²)
 xArmComponent.DoCommand(ctx, map[string]interface{}{"set_acceleration": 100.0})
 
@@ -196,6 +200,7 @@ xArmComponent.DoCommand(ctx, map[string]interface{}{
 **Python:**
 ```python
 await arm.do_command({"set_speed": 50.0, "set_acceleration": 100.0})
+resp = await arm.do_command({"get_speed": True})
 ```
 
 ### Joint Torques

--- a/arm/xarm.go
+++ b/arm/xarm.go
@@ -49,6 +49,8 @@ const (
 	gripperPositionKey       = "gripper_position"
 	setAcckey                = "set_acceleration"
 	setSpeedKey              = "set_speed"
+	getSpeedKey              = "get_speed"
+	speedKey                 = "speed_degs_per_sec"
 	grabVacuumKey            = "grab_vacuum"
 	openVacuumKey            = "open_vacuum"
 	clearErrorKey            = "clear_error"
@@ -842,6 +844,13 @@ func (x *xArm) DoCommand(ctx context.Context, cmd map[string]any) (map[string]an
 		x.confLock.Lock()
 		x.speed = utils.DegToRad(speed)
 		x.confLock.Unlock()
+		validCommand = true
+	}
+	if _, ok := cmd[getSpeedKey]; ok {
+		x.confLock.Lock()
+		speed := utils.RadToDeg(x.speed)
+		x.confLock.Unlock()
+		resp[speedKey] = speed
 		validCommand = true
 	}
 	if val, ok := cmd[setAcckey]; ok {

--- a/arm/xarm_test.go
+++ b/arm/xarm_test.go
@@ -1,6 +1,7 @@
 package arm
 
 import (
+	"context"
 	"math"
 	"os"
 	"path/filepath"
@@ -12,6 +13,19 @@ import (
 	"go.viam.com/rdk/utils"
 	"go.viam.com/test"
 )
+
+func TestDoCommandGetsCurrentSpeed(t *testing.T) {
+	x := &xArm{speed: utils.DegToRad(20)}
+	resp, err := x.DoCommand(context.Background(), map[string]any{getSpeedKey: true})
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, resp[speedKey], test.ShouldEqual, 20.0)
+
+	_, err = x.DoCommand(context.Background(), map[string]any{setSpeedKey: 8.0})
+	test.That(t, err, test.ShouldBeNil)
+	resp, err = x.DoCommand(context.Background(), map[string]any{getSpeedKey: true})
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, resp[speedKey], test.ShouldEqual, 8.0)
+}
 
 func TestConnectionTypeFromCmd(t *testing.T) {
 	test.That(t, connectionTypeFromCmd(map[string]any{connectionTypeKey: "contact"}, submodelV1),


### PR DESCRIPTION
Summary
- add a read-only get_speed DoCommand response
- return the arm's current runtime speed in speed_degs_per_sec
- document the Go and Python calls

Why
Consumers that temporarily change the module-global arm speed need to restore the actual prior runtime value, which may differ from static configuration.

Testing
- go test ./...
- go vet ./...