### PR TITLE
docs: nest arm DoCommand reference under Configure your xArm

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,9 @@ This module is particularly useful in applications that require an xArm to be op
   - [Networking](#networking)
   - [Trajectory Generator](#trajectory-generator)
   - [Using within a Frame System](#using-within-a-frame-system)
-- [Error Handling](#error-handling)
-- [DoCommand Reference](#docommand-reference)
-- [UFactory Studio Proxy](#ufactory-studio-proxy)
+  - [Error Handling](#error-handling)
+  - [DoCommand Reference](#docommand-reference)
+  - [UFactory Studio Proxy](#ufactory-studio-proxy)
 - [Gripper](#gripper)
 - [Gripper Lite](#gripper-lite)
 - [Vacuum Gripper](#vacuum-gripper)
@@ -146,7 +146,7 @@ For an attached gripper, set its parent to the arm's name:
 }
 ```
 
-## Error Handling
+### Error Handling
 
 When a collision or other fault occurs, the arm enters an error state and will not accept motion commands. The driver attempts to clear transient errors automatically on each command. A collision (overcurrent error) requires manual intervention:
 
@@ -172,11 +172,11 @@ resp, _ := xArmComponent.DoCommand(context.Background(), map[string]interface{}{
 // resp["error info"] contains raw error bytes
 ```
 
-## DoCommand Reference
+### DoCommand Reference
 
 The following commands are available via `DoCommand` on the arm component.
 
-### Speed and Acceleration
+#### Speed and Acceleration
 
 **Go:**
 ```go
@@ -198,14 +198,14 @@ xArmComponent.DoCommand(ctx, map[string]interface{}{
 await arm.do_command({"set_speed": 50.0, "set_acceleration": 100.0})
 ```
 
-### Joint Torques
+#### Joint Torques
 
 ```go
 resp, err := xArmComponent.DoCommand(ctx, map[string]interface{}{"load": ""})
 // resp["load"] contains a []float64 of per-joint torque values
 ```
 
-### UFactory Gripper Control (via arm DoCommand)
+#### UFactory Gripper Control (via arm DoCommand)
 
 > [!NOTE]
 > `"setup_gripper": true` must be included in any gripper move command.
@@ -235,7 +235,7 @@ resp, _ := xArmComponent.DoCommand(ctx, map[string]interface{}{"get_gripper_spee
 // resp["gripper_speed"]
 ```
 
-### Vacuum Gripper Control (via arm DoCommand)
+#### Vacuum Gripper Control (via arm DoCommand)
 
 ```go
 // Activate suction (grab)
@@ -260,7 +260,7 @@ xArmComponent.DoCommand(ctx, map[string]interface{}{
 })
 ```
 
-### Manual Mode (Teaching Mode)
+#### Manual Mode (Teaching Mode)
 
 Manual mode puts the arm into zero-gravity mode, allowing free movement by hand with gravity compensation active. Servos remain engaged — do not disable them.
 
@@ -275,7 +275,7 @@ xArmComponent.DoCommand(ctx, map[string]interface{}{"exit_manual_mode": true})
 > [!CAUTION]
 > Ensure the arm's payload and mounting orientation are correctly configured before entering manual mode, or gravity compensation will be inaccurate and the arm may drift.
 
-## UFactory Studio Proxy
+### UFactory Studio Proxy
 
 The arm hosts UFactory Studio at `http://<arm-ip>:18333`. When viam-server and the arm are on different subnets (e.g., direct Ethernet connection), Studio may not be reachable from your browser.
 


### PR DESCRIPTION
## Problem

The DoCommand section for the arm models doesn't appear on the Viam app's model pages.

All four arm models in `meta.json` point at `README.md#configure-your-xarm`. The app renders a model's section from that anchor up to the next heading at the same level, so the section ended at `## Error Handling` and everything after it, including the whole `## DoCommand Reference`, was cut off.

## Fix

Demote the arm-related h2 sections to h3 under `## Configure your xArm`, and their subsections from h3 to h4:

- `Error Handling`
- `DoCommand Reference` (Speed and Acceleration, Joint Torques, UFactory Gripper Control, Vacuum Gripper Control, Manual Mode)
- `UFactory Studio Proxy`

The rendered section now runs from `## Configure your xArm` to `## Gripper`, so the arm DoCommands are included. The Contents list is re-nested to match.

Heading text is unchanged, so `#error-handling`, `#docommand-reference`, and `#ufactory-studio-proxy` all still resolve and `meta.json` needs no change.

The gripper models are unaffected: `#gripper` and `#gripper-lite` already contain their own `### DoCommand`, and the vacuum gripper models have no DoCommand of their own since those commands go through the arm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)